### PR TITLE
Simplify Backend.list_dir to remove circular dependency

### DIFF
--- a/cloudpathlib/__init__.py
+++ b/cloudpathlib/__init__.py
@@ -1,9 +1,8 @@
 # order matters to avoid circular imports; path object, then backend
-from .backends.azure.azblobpath import AzureBlobPath
 from .backends.azure.azblobbackend import AzureBlobBackend
-
-from .backends.s3.s3path import S3Path
+from .backends.azure.azblobpath import AzureBlobPath
 from .backends.s3.s3backend import S3Backend
+from .backends.s3.s3path import S3Path
 
 
 # exceptions

--- a/cloudpathlib/backends/azure/azblobpath.py
+++ b/cloudpathlib/backends/azure/azblobpath.py
@@ -3,15 +3,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ...cloudpath import CloudPath
-import cloudpathlib
+from .azblobbackend import AzureBlobBackend
 
 
 class AzureBlobPath(CloudPath):
     cloud_prefix = "az://"
-
-    def __init__(self, *args, **kwargs):
-        self.backend_class = cloudpathlib.AzureBlobBackend
-        super().__init__(*args, **kwargs)
+    backend_class = AzureBlobBackend
 
     @property
     def drive(self):

--- a/cloudpathlib/backends/base.py
+++ b/cloudpathlib/backends/base.py
@@ -1,10 +1,8 @@
 import abc
+from typing import Iterable
 
 
 class Backend(abc.ABC):
-    class Meta:
-        path_class = None
-
     @abc.abstractmethod
     def download_file(self, cloud_path, local_path):
         pass
@@ -14,7 +12,7 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def list_dir(self, cloud_path, recursive):
+    def list_dir(self, cloud_path, recursive: bool) -> Iterable[str]:
         """ List all the files and folders in a directory.
 
         Parameters

--- a/cloudpathlib/backends/s3/s3path.py
+++ b/cloudpathlib/backends/s3/s3path.py
@@ -3,15 +3,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ...cloudpath import CloudPath
-import cloudpathlib
+from .s3backend import S3Backend
 
 
 class S3Path(CloudPath):
     cloud_prefix = "s3://"
-
-    def __init__(self, *args, **kwargs):
-        self.backend_class = cloudpathlib.S3Backend
-        super().__init__(*args, **kwargs)
+    backend_class = S3Backend
 
     @property
     def drive(self):


### PR DESCRIPTION
- Changes `Backend.list_dir` to yield strings, which removes the need for a `path_class` class attribute. This removes dependencies from Backend classes on CloudPath classes.
  - `CloudPath` methods that depend on `list_dir` are responsible for instantiating new `CloudPath` instances instead. 
- Remove inner `Meta` class from `CloudPath` and set contents as class attributes. 
- Add a few type hints. 
