### PR TITLE
Changed Example notebook to be 'Why cloudpathlib?'

### DIFF
--- a/docs/docs/why_cloudpathlib.ipynb
+++ b/docs/docs/why_cloudpathlib.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# cloudpathlib"
+    "# Why cloudpathlib?"
    ]
   },
   {
@@ -13,16 +13,23 @@
    "source": [
     "## We <3 pathlib\n",
     "\n",
-    "`pathlib` a wonderful standard for working with file paths. We can list all the files in a directory!"
+    "`pathlib` a wonderful tool for working with filesystem paths, available from the Python 3 standard library. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, we can easily list all the files in a directory."
    ]
   },
   {
@@ -56,9 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### An extention for everything\n",
-    "\n",
-    "We can learn everything there is to know about a Path and even do simple file manipulations!"
+    "There are methods to quickly learn everything there is to know about a filesystem path, and even do simple file manipulations."
    ]
   },
   {
@@ -72,12 +77,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Path:          /home/robert/code/cloudpathlib/docs/docs/example.ipynb\n",
+      "Path:          /Users/jqi/repos/cloudpathlib/docs/docs/example.ipynb\n",
       "Name:          example.ipynb\n",
       "Stem:          example\n",
       "Suffix:        .ipynb\n",
-      "With suffix:   /home/robert/code/cloudpathlib/docs/docs/example.cpp\n",
-      "Parent:        /home/robert/code/cloudpathlib/docs/docs\n",
+      "With suffix:   /Users/jqi/repos/cloudpathlib/docs/docs/example.cpp\n",
+      "Parent:        /Users/jqi/repos/cloudpathlib/docs/docs\n",
       "Read_text:\n",
       "{\n",
       " \"cells\": [\n",
@@ -85,14 +90,15 @@
       "   \"cell_type\": \"markdown\",\n",
       "   \"metadata\": {},\n",
       "   \"source\": [\n",
-      "    \"# cloudpathlib\"\n",
+      "    \"# Why cloudpathlib?\"\n",
       "   ]\n",
       "  },\n",
       "  {\n",
       "   \"cell_type\": \"markdown\",\n",
       "   \"metadata\": {},\n",
       "   \"source\": [\n",
-      "    \"## We <3 pathlib\\n\n"
+      "    \"## We <3 path\n",
+      "\n"
      ]
     }
    ],
@@ -105,18 +111,14 @@
     "print(f\"{'Suffix:':15}{notebook.suffix}\")\n",
     "print(f\"{'With suffix:':15}{notebook.with_suffix('.cpp')}\")\n",
     "print(f\"{'Parent:':15}{notebook.parent}\")\n",
-    "print(f\"{'Read_text:'}\\n{notebook.read_text()[:200]}\")"
+    "print(f\"{'Read_text:'}\\n{notebook.read_text()[:200]}\\n\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](https://pbpython.com/images/pathlib_cheatsheet_full.png)\n",
-    "\n",
-    "Credit to Chirs Moffat for this excellent cheat sheet, see it in full resolution here:\n",
-    "\n",
-    "https://github.com/chris1610/pbpython/blob/master/extras/Pathlib-Cheatsheet.pdf"
+    "If you're new to pathlib, we highly recommend it over the older `os.path` module. We find that it has a much more intuitive and convenient interface. The [official documentation](https://docs.python.org/3/library/pathlib.html) is a helpful reference, and we also recommend this [excellent cheat sheet by Chris Moffitt](https://github.com/chris1610/pbpython/blob/master/extras/Pathlib-Cheatsheet.pdf). "
    ]
   },
   {
@@ -125,17 +127,16 @@
    "source": [
     "### Cross-platform support\n",
     "\n",
-    "It \"just works\" on Windows too. Write path manipulations and have that run on anyone's machine!\n",
-    "\n",
+    "One great feature about using `pathlib` over regular strings is that it lets you write code with cross-platform file paths. It \"just works\" on Windows too. Write path manipulations that can run on anyone's machine!\n",
     "\n",
     "```python\n",
     "path = Path.home()\n",
     "path\n",
-    ">>> C:\\Users\\Jano\\\n",
+    ">>> C:\\Users\\DrivenData\\\n",
     "\n",
     "docs = path / 'Documents'\n",
     "docs\n",
-    ">>> C:\\Users\\Jano\\Documents\n",
+    ">>> C:\\Users\\DrivenData\\Documents\n",
     "```"
    ]
   },
@@ -143,12 +144,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## We <3 cloud storage\n",
+    "## We also <3 cloud storage\n",
     "\n",
-    "This is great, but I live in the future. Not every file I care about is on my machine. What do I do when I am working on S3? Do I have to download every file?\n",
+    "This is great, but I live in the future. Not every file I care about is on my machine. What do I do when I am working on S3? Do I have to explicitly download every file before I can do things with them?\n",
     "\n",
-    "\n",
-    "**Of course not!**"
+    "**Of course not, if you use cloudpathlib!**"
    ]
   },
   {
@@ -441,9 +441,9 @@
    "source": [
     "### Cloud hopping\n",
     "\n",
-    "Moving between cloud storage providers should be a simple as moving between disks on your computer. Let's say that the Senior Vice President of Tomfoolery comes to me and says, \"We've got a mandate to migrate our application to Azure storage from S3!\"\n",
+    "Moving between cloud storage providers should be a simple as moving between disks on your computer. Let's say that the Senior Vice President of Tomfoolery comes to me and says, \"We've got a mandate to migrate our application to Azure Blob Storage from S3!\"\n",
     "\n",
-    "No problem, if I used `cloudpathlib`!"
+    "No problem, if I used `cloudpathlib`! The `CloudPath` class constructor automatically dispatches to the appropriate concrete class, the same way that `pathlib.Path` does for different operating systems. "
    ]
   },
   {
@@ -502,7 +502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,7 +12,7 @@ extra_css:
 
 nav:
   - Home: "index.md"
-  - Example: "example.ipynb"
+  - Why cloudpathlib?: "why_cloudpathlib.ipynb"
   - Authentication: "authentication.ipynb"
   - Caching: "caching.ipynb"
   - API Reference:


### PR DESCRIPTION
So I felt like this notebook was more of an intro motivational narrative for why cloudpathlib is cool and useful. I renamed the notebook as such and fleshed out some of the prose. 

I also removed the thumnail of the pathlib cheat sheet. That had felt kind of jarring when reading the page. 