### PR TITLE
Tweak why_cloudpathlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ release-test: dist
 	twine upload --repository pypitest dist/*
 
 reqs:
-	pip install -r requirements-dev.txt
+	pip install -U -r requirements-dev.txt
 
 test: ## run tests with mocked cloud SDKs
 	python -m pytest -vv

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -337,7 +337,11 @@ class CloudPath(metaclass=CloudPathMeta):
             original_mtime = self._local.stat().st_mtime
 
         buffer = self._local.open(
-            mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline,
+            mode=mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
         )
 
         # write modes need special on closing the buffer
@@ -655,7 +659,8 @@ class CloudPath(metaclass=CloudPathMeta):
             or force_overwrite_to_cloud
         ):
             self.client._upload_file(
-                self._local, self,
+                self._local,
+                self,
             )
 
             # force cache time to match cloud times

--- a/docs/make_support_table.py
+++ b/docs/make_support_table.py
@@ -34,7 +34,9 @@ def print_table():
 
     md = (
         df.reset_index()
-        .sort_values(["sort_order", "Methods + properties"],)
+        .sort_values(
+            ["sort_order", "Methods + properties"],
+        )
         .set_index("Methods + properties")
         .drop(["sort_order", "base"], axis=1)
         .replace({True: "✅", False: "❌"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,10 @@ def azure_rig(request, monkeypatch, assets_dir):
         )
 
     rig = CloudProviderTestRig(
-        path_class=AzureBlobPath, client_class=AzureBlobClient, drive=drive, test_dir=test_dir,
+        path_class=AzureBlobPath,
+        client_class=AzureBlobClient,
+        drive=drive,
+        test_dir=test_dir,
     )
 
     rig.client_class().set_as_default_client()  # set default client
@@ -127,7 +130,9 @@ def s3_rig(request, monkeypatch, assets_dir):
     else:
         # Mock cloud SDK
         monkeypatch.setattr(
-            cloudpathlib.s3.s3client, "Session", mocked_session_class_factory(test_dir),
+            cloudpathlib.s3.s3client,
+            "Session",
+            mocked_session_class_factory(test_dir),
         )
 
     rig = CloudProviderTestRig(


### PR DESCRIPTION
 - Use actual test buckets in the notebook
 - Also, show iterdir in action
 - <3 to the heart eyes emoji

-----------

This consistently failed for me without the change here to cloudpath.py

@jayqi any thoughts about the risk of that change or alternative implementations? It feels a little hacky, but since we are explicitly setting mtime, it seems like if we discover we have time traveled backwards, it's ok to get a little hamhanded in dragging ourselves into the future.

