### PR TITLE
Fix type check to be Sequence

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -453,7 +453,7 @@ class CloudPath(metaclass=CloudPathMeta):
             path_version = _resolve(path_version)
             return self._new_cloudpath(path_version)
 
-        if isinstance(path_version, collections.abc.Iterable) and isinstance(
+        if isinstance(path_version, collections.abc.Sequence) and isinstance(
             path_version[0], PurePosixPath
         ):
             return [


### PR DESCRIPTION
This check here was incorrectly checking for an `Iterable`. In order to do `path_version[0]`, it needs to be a `Sequence`, which lets you do `__getitem__` with an index.

I think `Sequence` is the right check anyways. pathlib's internal class for the `parents` property is a subclass of `Sequence`. 