### PR TITLE
[WIP] Proof of concept fsspec integration

### DIFF
--- a/cloudpathlib/__init__.py
+++ b/cloudpathlib/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from .azure.azblobclient import AzureBlobClient
@@ -39,3 +40,13 @@ __all__ = [
     "S3Client",
     "S3Path",
 ]
+
+try:
+    FSSPEC_MODE = int(os.getenv("FSSPEC_MODE", 0))
+except ValueError:
+    FSSPEC_MODE = 0
+
+if FSSPEC_MODE:
+    import cloudpathlib.fsspec
+
+    implementation_registry = cloudpathlib.fsspec.implementation_registry

--- a/cloudpathlib/fsspec/__init__.py
+++ b/cloudpathlib/fsspec/__init__.py
@@ -1,0 +1,7 @@
+from .fsspecclient import FsspecClient
+from .fsspecpath import FsspecPath
+
+__all__ = [
+    "FsspecClient",
+    "FsspecPath",
+]

--- a/cloudpathlib/fsspec/__init__.py
+++ b/cloudpathlib/fsspec/__init__.py
@@ -1,7 +1,9 @@
 from .fsspecclient import FsspecClient
 from .fsspecpath import FsspecPath
+from .implementations import implementation_registry
 
 __all__ = [
     "FsspecClient",
     "FsspecPath",
+    "implementation_registry",
 ]

--- a/cloudpathlib/fsspec/fsspecclient.py
+++ b/cloudpathlib/fsspec/fsspecclient.py
@@ -1,0 +1,81 @@
+import os
+from typing import Iterable, Optional, Union
+
+from ..client import Client
+from .fsspecpath import fsspec_implementation, FsspecPath
+
+from fsspec.spec import AbstractFileSystem
+from s3fs import S3FileSystem
+
+
+class FsspecClient(Client):
+    _cloud_meta = fsspec_implementation
+
+    def __init__(
+        self,
+        filesystem: Optional[AbstractFileSystem] = None,
+        local_cache_dir: Optional[Union[str, os.PathLike]] = None,
+    ):
+        self.filesystem = S3FileSystem()
+        super().__init__(local_cache_dir=local_cache_dir)
+
+    def _download_file(
+        self, cloud_path: FsspecPath, local_path: Union[str, os.PathLike]
+    ) -> Union[str, os.PathLike]:
+        self.filesystem.get_file(rpath=cloud_path._no_prefix, lpath=local_path)
+
+    def _exists(self, cloud_path: FsspecPath) -> bool:
+        return self.filesystem.exists(cloud_path._no_prefix)
+
+    def _is_dir(self, cloud_path: FsspecPath) -> bool:
+        return self.filesystem.isdir(cloud_path._no_prefix)
+
+    def _is_file(self, cloud_path: FsspecPath) -> bool:
+        return self.filesystem.isfile(cloud_path._no_prefix)
+
+    def _list_dir(self, cloud_path: FsspecPath, recursive=False) -> Iterable[FsspecPath]:
+        if recursive:
+            return (
+                self.CloudPath(cloud_path.cloud_prefix + obj)
+                for obj in self.filesystem.glob(f"{cloud_path._no_prefix}/**/*", detail=False)
+            )
+        return (
+            self.CloudPath(cloud_path.cloud_prefix + obj)
+            for obj in self.filesystem.ls(cloud_path._no_prefix, detail=False)
+        )
+
+    def _move_file(self, src: FsspecPath, dst: FsspecPath) -> FsspecPath:
+        self.filesystem.mv(src, dst, recursive=False)
+        return dst
+
+    def _remove(self, cloud_path: FsspecPath) -> None:
+        self.filesystem.rm(cloud_path._no_prefix)
+
+    def _stat(self, cloud_path: FsspecPath) -> os.stat_result:
+        info = self.filesystem.info(cloud_path._no_prefix)
+
+        return os.stat_result(
+            (
+                info.get("mode"),  # mode
+                None,  # ino
+                cloud_path.cloud_prefix,  # dev,
+                None,  # nlink,
+                info.get("uid"),  # uid,
+                info.get("gid"),  # gid,
+                info.get("size"),  # size,
+                None,  # atime,
+                info.get("mtime"),  # mtime,
+                None,  # ctime,
+            )
+        )
+
+    def _touch(self, cloud_path: FsspecPath) -> None:
+        self.filesystem.touch(cloud_path._no_prefix)
+
+    def _upload_file(
+        self, local_path: Union[str, os.PathLike], cloud_path: FsspecPath
+    ) -> FsspecPath:
+        self.filesystem.put_file(lpath=local_path, rpath=cloud_path._no_prefix)
+
+
+fsspec_implementation._client_class = FsspecClient

--- a/cloudpathlib/fsspec/fsspecclient.py
+++ b/cloudpathlib/fsspec/fsspecclient.py
@@ -59,7 +59,7 @@ class FsspecClient(Client):
 
         return os.stat_result(
             (  # type: ignore
-                info.get("mode"),  # mode
+                info.get("mode"),  # type: ignore # mode
                 None,  # ino
                 cloud_path.cloud_prefix,  # dev,
                 None,  # nlink,

--- a/cloudpathlib/fsspec/fsspecpath.py
+++ b/cloudpathlib/fsspec/fsspecpath.py
@@ -1,0 +1,37 @@
+from typing import TYPE_CHECKING
+
+from ..cloudpath import CloudImplementation, CloudPath
+
+
+if TYPE_CHECKING:
+    from .fsspecclient import FsspecClient
+
+fsspec_implementation = CloudImplementation()
+
+
+class FsspecPath(CloudPath):
+    client: "FsspecClient"
+    cloud_prefix = "s3://"
+    _cloud_meta = fsspec_implementation
+
+    @property
+    def drive(self) -> str:
+        return self._no_prefix.split("/", 1)[0]
+
+    def is_dir(self) -> bool:
+        return self.client._is_dir(self)
+
+    def is_file(self) -> bool:
+        return self.client._is_file(self)
+
+    def mkdir(self):
+        pass
+
+    def stat(self):
+        return self.client._stat(self)
+
+    def touch(self):
+        self.client._touch(self)
+
+
+fsspec_implementation._path_class = FsspecPath

--- a/cloudpathlib/fsspec/fsspecpath.py
+++ b/cloudpathlib/fsspec/fsspecpath.py
@@ -1,18 +1,14 @@
 from typing import TYPE_CHECKING
 
-from ..cloudpath import CloudImplementation, CloudPath
+from ..cloudpath import CloudPath
 
 
 if TYPE_CHECKING:
     from .fsspecclient import FsspecClient
 
-fsspec_implementation = CloudImplementation()
-
 
 class FsspecPath(CloudPath):
     client: "FsspecClient"
-    cloud_prefix = "s3://"
-    _cloud_meta = fsspec_implementation
 
     @property
     def drive(self) -> str:
@@ -32,6 +28,3 @@ class FsspecPath(CloudPath):
 
     def touch(self):
         self.client._touch(self)
-
-
-fsspec_implementation._path_class = FsspecPath

--- a/cloudpathlib/fsspec/implementations.py
+++ b/cloudpathlib/fsspec/implementations.py
@@ -1,0 +1,83 @@
+import importlib
+import os
+
+from fsspec.registry import known_implementations
+
+from ..cloudpath import CloudImplementation, CloudPathMeta, CloudPath
+from .fsspecclient import FsspecClient
+from .fsspecpath import FsspecPath
+
+
+implementation_registry = {}
+
+
+def register_fsspec_implementation(protocol: str):
+    implementation = CloudImplementation(name=f"fsspec-{protocol}")
+
+    # known_implementations is a dictionary:
+    # {
+    #     protocol: {
+    #         "class": filesystem_class_import_path,
+    #     },
+    # }
+    import_path = known_implementations[protocol]["class"]
+    module_name, class_name = import_path.rsplit(".", 1)
+
+    try:
+        filesystem_class = getattr(importlib.import_module(module_name), class_name)
+    except ImportError:
+        filesystem_class = type(class_name, (), {})
+        implementation.dependencies_loaded = False
+
+    class_name_prefix = filesystem_class.__name__.rpartition("FileSystem")[0]
+
+    # Create concrete client class
+    class _ConcreteClient(FsspecClient):
+        _filesystem_class = filesystem_class
+
+    _ConcreteClient.__name__ = f"{class_name_prefix}Client"
+    _ConcreteClient._cloud_meta = implementation
+    implementation._client_class = _ConcreteClient
+
+    # Create concrete path class
+    class _ConcretePath(FsspecPath):
+        cloud_prefix = f"{protocol}://"
+
+    _ConcretePath.__name__ = f"{class_name_prefix}Path"
+    _ConcretePath._cloud_meta = implementation
+    implementation._path_class = _ConcretePath
+
+    # register implementation
+    implementation_registry[protocol] = implementation
+
+
+for protocol in known_implementations:
+    register_fsspec_implementation(protocol)
+
+
+def dispatch_fsspec_path(cloud_path, *args, **kwargs):
+    protocol = str(cloud_path).partition("://")[0]
+    if protocol in implementation_registry:
+        path_class = implementation_registry[protocol].path_class()
+        # Instantiate path_class instance
+        new_obj = path_class.__new__(path_class, cloud_path, *args, **kwargs)
+        if isinstance(new_obj, path_class):
+            path_class.__init__(new_obj, cloud_path, *args, **kwargs)
+        return new_obj
+    raise Exception(
+        f"Path {cloud_path} does not begin with a known prefix "
+        f"{list(implementation_registry.keys())}."
+    )
+
+
+try:
+    FSSPEC_MODE = int(os.getenv("FSSPEC_MODE", 0))
+except ValueError:
+    FSSPEC_MODE = 0
+
+if FSSPEC_MODE:
+    # Replace CloudPath dispatching with dispatch to fsspec class
+    CloudPathMeta._dispatch_gates = [(CloudPath, dispatch_fsspec_path)]
+else:
+    # Add FsspecPath as an additional dispatch gate
+    CloudPathMeta._dispatch_gates.append((FsspecPath, dispatch_fsspec_path))

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ def load_requirements(path: Path):
 
 readme = Path("README.md").read_text(encoding="UTF-8")
 
+# Standard Extras
 extra_reqs = {}
 for req_path in (Path(__file__).parent / "requirements").glob("*.txt"):
     if req_path.stem == "base":
@@ -31,6 +32,28 @@ for req_path in (Path(__file__).parent / "requirements").glob("*.txt"):
         raise ValueError("'all' is a reserved keyword and can't be used for a cloud provider key")
     extra_reqs[req_path.stem] = load_requirements(req_path)
 extra_reqs["all"] = list(chain(*extra_reqs.values()))
+
+# fsspec Extras
+fsspec_extras = {
+    "abfs": ["adlfs"],
+    "adl": ["adlfs"],
+    "dask": ["dask", "distributed"],
+    "dropbox": ["dropboxdrivefs", "requests", "dropbox"],
+    "gcs": ["gcsfs"],
+    "git": ["pygit2"],
+    "github": ["requests"],
+    "gs": ["gcsfs"],
+    "hdfs": ["pyarrow"],
+    "http": ["requests", "aiohttp"],
+    "sftp": ["paramiko"],
+    "s3": ["s3fs"],
+    "smb": ["smbprotocol"],
+    "ssh": ["paramiko"],
+}
+extra_reqs["fsspec"] = ["fsspec"]
+for name, reqs in fsspec_extras.items():
+    extra_reqs[f"fsspec-{name}"] = ["fsspec"] + reqs
+extra_reqs["fsspec-all"] = list(set(chain(*fsspec_extras.values())))
 
 setup(
     author="DrivenData",


### PR DESCRIPTION
Implementation of `FsspecClient` and `FsspecPath` that work with an fsspec concrete filesystem implementation. 

Follow up on #96 

---

- New abstract `FsspecClient`, `FsspecPath` classes. Each registered implementation in [fsspec.registry](https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/registry.html#ReadOnlyRegistry) has subclasses autogenerated, e.g., `S3Path`, `GCSPath`, `HTTPPath`. 
- `FsspecPath` will automatically dispatch to correct subclass, the same way `CloudPath` does. This dispatching is isolated to `FsspecPath`; `CloudPath` still only dispatches to original implementations. 
  - Running environment variable `FSSPEC_MODE=1` will _replace_ `CloudPath`'s dispatching so that it will dispatch to fsspec subclasses instead of the normal ones. 
- New extras. 
  - `[fsspec]` will install `fsspec`. 
  - Each extras from `fsspec` has been copied to `[fsspec-<name>]`, e.g.`fsspec-s3fs`. 
  - `[fsspec-all]` will install _all_ `fsspec` extras.
  - original `[all]` does not include any fsspec extras