### PR TITLE
Reduce network overhead of _refresh_cache

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -46,6 +46,15 @@ class DirectoryNotEmpty(Exception):
     pass
 
 
+class NoStat(Exception):
+    """Used if stats cannot be retrieved; e.g., file does not exist
+    or for some backends path is a directory (which doesn't have)
+    stats available.
+    """
+
+    pass
+
+
 class CloudImplementation:
     _client_class = None
     _path_class = None
@@ -610,18 +619,17 @@ class CloudPath(metaclass=CloudPathMeta):
         return self.client.CloudPath(path)
 
     def _refresh_cache(self, force_overwrite_from_cloud=False):
-        # nothing to cache if the file does not exist; happens when creating
-        # new files that will be uploaded
-        if not self.exists():
+        try:
+            stats = self.stat()
+        except NoStat:
+            # nothing to cache if the file does not exist; happens when creating
+            # new files that will be uploaded
             return
-
-        if self.is_dir():
-            raise ValueError("Only individual files can be cached")
 
         # if not exist or cloud newer
         if (
             not self._local.exists()
-            or (self._local.stat().st_mtime < self.stat().st_mtime)
+            or (self._local.stat().st_mtime < stats.st_mtime)
             or force_overwrite_from_cloud
         ):
             # ensure there is a home for the file
@@ -629,7 +637,7 @@ class CloudPath(metaclass=CloudPathMeta):
             self.download_to(self._local)
 
             # force cache time to match cloud times
-            os.utime(self._local, times=(self.stat().st_mtime, self.stat().st_mtime))
+            os.utime(self._local, times=(stats.st_mtime, stats.st_mtime))
 
         if self._dirty:
             raise OverwriteDirtyFile(
@@ -641,7 +649,7 @@ class CloudPath(metaclass=CloudPathMeta):
 
         # if local newer but not dirty, it was updated
         # by a separate process; do not overwrite unless forced to
-        if self._local.stat().st_mtime > self.stat().st_mtime:
+        if self._local.stat().st_mtime > stats.st_mtime:
             raise OverwriteNewerLocal(
                 f"Local file ({self._local}) for cloud path ({self}) is newer on disk, but "
                 f"is being requested for download from cloud. Either (1) push your changes to the cloud, "

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -84,10 +84,6 @@ class S3Client(Client):
         if not cloud_path.key:
             return "dir"
 
-        # short circuit files/dirs that are already in the cache
-        if cloud_path._local.exists():
-            return "file" if cloud_path._local.is_file() else "dir"
-
         # get first item by listing at least one key
         s3_obj = self._s3_file_query(cloud_path)
 

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -84,26 +84,26 @@ class S3Client(Client):
         if not cloud_path.key:
             return "dir"
 
+        # short circuit files/dirs that are already in the cache
+        if cloud_path._local.exists():
+            return "file" if cloud_path._local.is_file() else "dir"
+
+        # get first item by listing at least one key
         try:
-            obj = self.s3.ObjectSummary(cloud_path.bucket, cloud_path.key)
-            obj.get()
-            return "file"
-        except self.client.exceptions.NoSuchKey:
-            prefix = cloud_path.key
-            if prefix and not prefix.endswith("/"):
-                prefix += "/"
+            res = next(_ for _ in self._s3_file_query(cloud_path))
+        except StopIteration:
+            return None
 
-            # not a file, see if it is a directory
-            f = self.s3.Bucket(cloud_path.bucket).objects.filter(Prefix=prefix)
-
-            # at least one key with the prefix of the directory
-            if bool([_ for _ in f.limit(1)]):
-                return "dir"
-            else:
-                return None
+        # since S3 only returns files when filtering objects:
+        # if the first item key is equal to the path key, this is a file; else it is a dir
+        return "file" if res.key == cloud_path.key else "dir"
 
     def _exists(self, cloud_path: S3Path) -> bool:
-        return self._is_file_or_dir(cloud_path) in ["file", "dir"]
+        return len([_ for _ in self._s3_file_query(cloud_path)]) > 0
+
+    def _s3_file_query(self, cloud_path: S3Path):
+        """Boto3 query used for quick checks of existence and if path is file/dir"""
+        return self.s3.Bucket(cloud_path.bucket).objects.filter(Prefix=cloud_path.key).limit(1)
 
     def _list_dir(self, cloud_path: S3Path, recursive=False) -> Iterable[S3Path]:
         bucket = self.s3.Bucket(cloud_path.bucket)

--- a/cloudpathlib/s3/s3path.py
+++ b/cloudpathlib/s3/s3path.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
-from ..cloudpath import CloudPath, register_path_class
+from ..cloudpath import CloudPath, NoStat, register_path_class
 
 
 if TYPE_CHECKING:
@@ -41,8 +41,11 @@ class S3Path(CloudPath):
 
             tf.cleanup()
 
-    def stat(self):
-        meta = self.client._get_metadata(self)
+    def stat(self, cache_timeout=None):
+        try:
+            meta = self.client._get_metadata(self)
+        except self.client.client.exceptions.NoSuchKey:
+            raise NoStat(f"No stats available for {self}; it may be a directory or not exist.")
 
         return os.stat_result(
             (

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -125,7 +125,7 @@ class MockObjects:
         path = self.root / Prefix
 
         if path.is_file():
-            return MockCollection([path], self.root)
+            return MockCollection([PurePosixPath(path)], self.root)
 
         items = [
             PurePosixPath(f)
@@ -184,6 +184,10 @@ class MockBoto3Paginator:
 
         for ix in range(0, len(items), self.per_page):
             page = items[ix : ix + self.per_page]
-            dirs = [{"Prefix": str(_.relative_to(self.root))} for _ in page if _.is_dir()]
-            files = [{"Key": str(_.relative_to(self.root))} for _ in page if _.is_file()]
+            dirs = [
+                {"Prefix": str(_.relative_to(self.root).as_posix())} for _ in page if _.is_dir()
+            ]
+            files = [
+                {"Key": str(_.relative_to(self.root).as_posix())} for _ in page if _.is_file()
+            ]
             yield {"CommonPrefixes": dirs, "Contents": files}

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -123,6 +123,10 @@ class MockObjects:
 
     def filter(self, Prefix=""):
         path = self.root / Prefix
+
+        if path.is_file():
+            return MockCollection([path], self.root)
+
         items = [
             PurePosixPath(f)
             for f in path.glob("**/*")
@@ -175,10 +179,8 @@ class MockBoto3Paginator:
 
     def paginate(self, Bucket=None, Prefix="", Delimiter=None):
         new_dir = self.root / Prefix
-        items = []
-        for f in new_dir.iterdir():
-            if not f.name.startswith("."):
-                items.append(f)
+
+        items = [f for f in new_dir.iterdir() if not f.name.startswith(".")]
 
         for ix in range(0, len(items), self.per_page):
             page = items[ix : ix + self.per_page]


### PR DESCRIPTION
We used to do a lot of network calls in _refresh_cache, which slowed down scripts that looked at lots of files. This change makes it so `_refresh_cache` only needs one network call.

 - [x] Add a `NoStat` exception if we can't get stats for a particular path (two cases: could be directory or could not exist)
 - [x] Get stats once at top of call

Downsides:
 - We used to be able to provide a specific error if somehow you tried to cache a directory instead of a file. I don't think this will happen, so it probably is not worth the additional network call.


On a slow connection, it seems ~4x faster after removing the additional calls. (First `_refresh_cache` is slow because it actually downloads the file on my slow connection)

BEFORE:
<img width="777" alt="Screen Shot 2020-12-21 at 11 30 52 AM" src="https://user-images.githubusercontent.com/1799186/102837565-e5953c80-43b0-11eb-97d9-11752bf6554a.png">

AFTER:
<img width="1142" alt="Screen Shot 2020-12-21 at 11 25 52 AM" src="https://user-images.githubusercontent.com/1799186/102837597-f776df80-43b0-11eb-9ee7-8e35d4c6ea06.png">


Closes #110 