### PR TITLE
Add sleep and larger file to read/write test

### DIFF
--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -45,9 +45,15 @@ def test_file_read_writes(rig, tmp_path):
     p2 = rig.create_cloud_path("dir_0/not_a_file")
     p3 = rig.create_cloud_path("")
 
-    p.write_text("lalala")
-    assert p.read_text() == "lalala"
-    p2.write_text("lalala")
+    text = "lalala" * 10_000
+
+    p.write_text(text)
+    assert p.read_text() == text
+    p2.write_text(text)
+
+    # sleep between writes to p to ensure different
+    # modified times
+    sleep(1)
 
     p.write_bytes(p2.read_bytes())
     assert p.read_text() == p2.read_text()


### PR DESCRIPTION
We've been having intermittent failures of tests on our scheduled runs. Here is an example:
https://github.com/drivendataorg/cloudpathlib/actions/runs/490835874

This is likely related to the issues mentioned in: https://github.com/drivendataorg/cloudpathlib/issues/49

For now in our test suite I think we should stabilize the tests with a fix like this that covers what we intend to test. To do that, I increased the size of what we read/write to ensure these operations take long enough to complete both locally and against the cloud backends, and I added a sleep between the two writes to the file same file.

I did a "rerun all jobs" on the GitHub actions for this PR 3 times and all the tests passed in all of the iterations.