### PR TITLE
Google Cloud Storage Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,8 @@ jobs:
         env:
           LIVE_AZURE_CONTAINER: ${{ secrets.LIVE_AZURE_CONTAINER }}
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
+          LIVE_GS_BUCKET: ${{ secrets.LIVE_GS_BUCKET }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           LIVE_S3_BUCKET: ${{ secrets.LIVE_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,13 @@ jobs:
         run: |
           make test
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
       - name: Run live tests
         run: |
           make test-live-cloud
@@ -45,7 +52,6 @@ jobs:
           LIVE_AZURE_CONTAINER: ${{ secrets.LIVE_AZURE_CONTAINER }}
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
           LIVE_GS_BUCKET: ${{ secrets.LIVE_GS_BUCKET }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           LIVE_S3_BUCKET: ${{ secrets.LIVE_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ ENV/
 
 # IDE settings
 .vscode/
+
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,3 @@ ENV/
 
 # IDE settings
 .vscode/
-
-tmp/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ with CloudPath("s3://bucket/filename.txt").open("w+") as f:
 ## Why use cloudpathlib?
 
  - **Familiar**: If you know how to interact with `Path`, you know how to interact with `CloudPath`. All of the cloud-relevant `Path` methods are implemented.
- - **Supported clouds**: AWS S3 and Azure Blob Storage are implemented. Google Cloud Storage and FTP are on the way.
+ - **Supported clouds**: AWS S3, Google Cloud Storage, and Azure Blob Storage are implemented. FTP is on the way.
  - **Extensible**: The base classes do most of the work generically, so implementing two small classes `MyPath` and `MyClient` is all you need to add support for a new cloud storage service.
  - **Read/write support**: Reading just works. Using the `write_text`, `write_bytes` or `.open('w')` methods will all upload your changes to cloud storage without any additional file management as a developer.
  - **Seamless caching**: Files are downloaded locally only when necessary. You can also easily pass a persistent cache folder so that across processes and sessions you only re-download what is necessary.
@@ -27,15 +27,15 @@ with CloudPath("s3://bucket/filename.txt").open("w+") as f:
 
 ## Installation
 
-`cloudpathlib` depends on the cloud services' SDKs (e.g., `boto3`, `azure-storage-blob`) to communicate with their respective storage service. If you try to use cloud paths for a cloud service for which you don't have dependencies installed, `cloudpathlib` will error and let you know what you need to install.
+`cloudpathlib` depends on the cloud services' SDKs (e.g., `boto3`, `google-cloud-storage`, `azure-storage-blob`) to communicate with their respective storage service. If you try to use cloud paths for a cloud service for which you don't have dependencies installed, `cloudpathlib` will error and let you know what you need to install.
 
 To install a cloud service's SDK dependency when installing `cloudpathlib`, you need to specify it using pip's ["extras"](https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras) specification. For example:
 
 ```bash
-pip install cloudpathlib[s3,azure]
+pip install cloudpathlib[s3,gs,azure]
 ```
 
-Currently supported cloud storage services are: `azure`, `s3`. You can also use `all` to install all available services' dependencies.
+Currently supported cloud storage services are: `azure`, `gs`, `s3`. You can also use `all` to install all available services' dependencies.
 
 If you do not specify any extras or separately install any cloud SDKs, you will only be able to develop with the base classes for rolling your own cloud path class.
 

--- a/README.md
+++ b/README.md
@@ -114,73 +114,73 @@ list(root_dir.glob('**/*.txt'))
 
 Most methods and properties from `pathlib.Path` are supported except for the ones that don't make sense in a cloud context. There are a few additional methods or properties that relate to specific cloud services or specifically for cloud paths.
 
-| Methods + properties   | `AzureBlobPath`   | `S3Path`   |
-|:-----------------------|:------------------|:-----------|
-| `anchor`               | ✅                | ✅         |
-| `as_uri`               | ✅                | ✅         |
-| `drive`                | ✅                | ✅         |
-| `exists`               | ✅                | ✅         |
-| `glob`                 | ✅                | ✅         |
-| `is_dir`               | ✅                | ✅         |
-| `is_file`              | ✅                | ✅         |
-| `iterdir`              | ✅                | ✅         |
-| `joinpath`             | ✅                | ✅         |
-| `match`                | ✅                | ✅         |
-| `mkdir`                | ✅                | ✅         |
-| `name`                 | ✅                | ✅         |
-| `open`                 | ✅                | ✅         |
-| `parent`               | ✅                | ✅         |
-| `parents`              | ✅                | ✅         |
-| `parts`                | ✅                | ✅         |
-| `read_bytes`           | ✅                | ✅         |
-| `read_text`            | ✅                | ✅         |
-| `rename`               | ✅                | ✅         |
-| `replace`              | ✅                | ✅         |
-| `rglob`                | ✅                | ✅         |
-| `rmdir`                | ✅                | ✅         |
-| `samefile`             | ✅                | ✅         |
-| `stat`                 | ✅                | ✅         |
-| `stem`                 | ✅                | ✅         |
-| `suffix`               | ✅                | ✅         |
-| `suffixes`             | ✅                | ✅         |
-| `touch`                | ✅                | ✅         |
-| `unlink`               | ✅                | ✅         |
-| `with_name`            | ✅                | ✅         |
-| `with_suffix`          | ✅                | ✅         |
-| `write_bytes`          | ✅                | ✅         |
-| `write_text`           | ✅                | ✅         |
-| `absolute`             | ❌                | ❌         |
-| `as_posix`             | ❌                | ❌         |
-| `chmod`                | ❌                | ❌         |
-| `cwd`                  | ❌                | ❌         |
-| `expanduser`           | ❌                | ❌         |
-| `group`                | ❌                | ❌         |
-| `home`                 | ❌                | ❌         |
-| `is_absolute`          | ❌                | ❌         |
-| `is_block_device`      | ❌                | ❌         |
-| `is_char_device`       | ❌                | ❌         |
-| `is_fifo`              | ❌                | ❌         |
-| `is_mount`             | ❌                | ❌         |
-| `is_reserved`          | ❌                | ❌         |
-| `is_socket`            | ❌                | ❌         |
-| `is_symlink`           | ❌                | ❌         |
-| `lchmod`               | ❌                | ❌         |
-| `link_to`              | ❌                | ❌         |
-| `lstat`                | ❌                | ❌         |
-| `owner`                | ❌                | ❌         |
-| `relative_to`          | ❌                | ❌         |
-| `resolve`              | ❌                | ❌         |
-| `root`                 | ❌                | ❌         |
-| `symlink_to`           | ❌                | ❌         |
-| `cloud_prefix`         | ✅                | ✅         |
-| `download_to`          | ✅                | ✅         |
-| `etag`                 | ✅                | ✅         |
-| `is_valid_cloudpath`   | ✅                | ✅         |
-| `blob`                 | ✅                | ❌         |
-| `bucket`               | ❌                | ✅         |
-| `container`            | ✅                | ❌         |
-| `key`                  | ❌                | ✅         |
-| `md5`                  | ✅                | ❌         |
+| Methods + properties   | `AzureBlobPath`   | `GSPath`   | `S3Path`   |
+|:-----------------------|:------------------|:-----------|:-----------|
+| `anchor`               | ✅                | ✅         | ✅         |
+| `as_uri`               | ✅                | ✅         | ✅         |
+| `drive`                | ✅                | ✅         | ✅         |
+| `exists`               | ✅                | ✅         | ✅         |
+| `glob`                 | ✅                | ✅         | ✅         |
+| `is_dir`               | ✅                | ✅         | ✅         |
+| `is_file`              | ✅                | ✅         | ✅         |
+| `iterdir`              | ✅                | ✅         | ✅         |
+| `joinpath`             | ✅                | ✅         | ✅         |
+| `match`                | ✅                | ✅         | ✅         |
+| `mkdir`                | ✅                | ✅         | ✅         |
+| `name`                 | ✅                | ✅         | ✅         |
+| `open`                 | ✅                | ✅         | ✅         |
+| `parent`               | ✅                | ✅         | ✅         |
+| `parents`              | ✅                | ✅         | ✅         |
+| `parts`                | ✅                | ✅         | ✅         |
+| `read_bytes`           | ✅                | ✅         | ✅         |
+| `read_text`            | ✅                | ✅         | ✅         |
+| `rename`               | ✅                | ✅         | ✅         |
+| `replace`              | ✅                | ✅         | ✅         |
+| `rglob`                | ✅                | ✅         | ✅         |
+| `rmdir`                | ✅                | ✅         | ✅         |
+| `samefile`             | ✅                | ✅         | ✅         |
+| `stat`                 | ✅                | ✅         | ✅         |
+| `stem`                 | ✅                | ✅         | ✅         |
+| `suffix`               | ✅                | ✅         | ✅         |
+| `suffixes`             | ✅                | ✅         | ✅         |
+| `touch`                | ✅                | ✅         | ✅         |
+| `unlink`               | ✅                | ✅         | ✅         |
+| `with_name`            | ✅                | ✅         | ✅         |
+| `with_suffix`          | ✅                | ✅         | ✅         |
+| `write_bytes`          | ✅                | ✅         | ✅         |
+| `write_text`           | ✅                | ✅         | ✅         |
+| `absolute`             | ❌                | ❌         | ❌         |
+| `as_posix`             | ❌                | ❌         | ❌         |
+| `chmod`                | ❌                | ❌         | ❌         |
+| `cwd`                  | ❌                | ❌         | ❌         |
+| `expanduser`           | ❌                | ❌         | ❌         |
+| `group`                | ❌                | ❌         | ❌         |
+| `home`                 | ❌                | ❌         | ❌         |
+| `is_absolute`          | ❌                | ❌         | ❌         |
+| `is_block_device`      | ❌                | ❌         | ❌         |
+| `is_char_device`       | ❌                | ❌         | ❌         |
+| `is_fifo`              | ❌                | ❌         | ❌         |
+| `is_mount`             | ❌                | ❌         | ❌         |
+| `is_reserved`          | ❌                | ❌         | ❌         |
+| `is_socket`            | ❌                | ❌         | ❌         |
+| `is_symlink`           | ❌                | ❌         | ❌         |
+| `lchmod`               | ❌                | ❌         | ❌         |
+| `link_to`              | ❌                | ❌         | ❌         |
+| `lstat`                | ❌                | ❌         | ❌         |
+| `owner`                | ❌                | ❌         | ❌         |
+| `relative_to`          | ❌                | ❌         | ❌         |
+| `resolve`              | ❌                | ❌         | ❌         |
+| `root`                 | ❌                | ❌         | ❌         |
+| `symlink_to`           | ❌                | ❌         | ❌         |
+| `cloud_prefix`         | ✅                | ✅         | ✅         |
+| `download_to`          | ✅                | ✅         | ✅         |
+| `etag`                 | ✅                | ✅         | ✅         |
+| `is_valid_cloudpath`   | ✅                | ✅         | ✅         |
+| `blob`                 | ✅                | ✅         | ❌         |
+| `bucket`               | ❌                | ✅         | ✅         |
+| `container`            | ✅                | ❌         | ❌         |
+| `key`                  | ❌                | ❌         | ✅         |
+| `md5`                  | ✅                | ❌         | ❌         |
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ list(root_dir.glob('**/*.txt'))
 
 Most methods and properties from `pathlib.Path` are supported except for the ones that don't make sense in a cloud context. There are a few additional methods or properties that relate to specific cloud services or specifically for cloud paths.
 
-| Methods + properties   | `AzureBlobPath`   | `GSPath`   | `S3Path`   |
+| Methods + properties   | `AzureBlobPath`   | `S3Path`   | `GSPath`   |
 |:-----------------------|:------------------|:-----------|:-----------|
 | `anchor`               | ✅                | ✅         | ✅         |
 | `as_uri`               | ✅                | ✅         | ✅         |
@@ -161,6 +161,7 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 | `is_char_device`       | ❌                | ❌         | ❌         |
 | `is_fifo`              | ❌                | ❌         | ❌         |
 | `is_mount`             | ❌                | ❌         | ❌         |
+| `is_relative_to`       | ❌                | ❌         | ❌         |
 | `is_reserved`          | ❌                | ❌         | ❌         |
 | `is_socket`            | ❌                | ❌         | ❌         |
 | `is_symlink`           | ❌                | ❌         | ❌         |
@@ -168,18 +169,22 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 | `link_to`              | ❌                | ❌         | ❌         |
 | `lstat`                | ❌                | ❌         | ❌         |
 | `owner`                | ❌                | ❌         | ❌         |
+| `readlink`             | ❌                | ❌         | ❌         |
 | `relative_to`          | ❌                | ❌         | ❌         |
 | `resolve`              | ❌                | ❌         | ❌         |
 | `root`                 | ❌                | ❌         | ❌         |
 | `symlink_to`           | ❌                | ❌         | ❌         |
+| `with_stem`            | ❌                | ❌         | ❌         |
 | `cloud_prefix`         | ✅                | ✅         | ✅         |
 | `download_to`          | ✅                | ✅         | ✅         |
 | `etag`                 | ✅                | ✅         | ✅         |
+| `fspath`               | ✅                | ✅         | ✅         |
 | `is_valid_cloudpath`   | ✅                | ✅         | ✅         |
-| `blob`                 | ✅                | ✅         | ❌         |
+| `rmtree`               | ✅                | ✅         | ✅         |
+| `blob`                 | ✅                | ❌         | ✅         |
 | `bucket`               | ❌                | ✅         | ✅         |
 | `container`            | ✅                | ❌         | ❌         |
-| `key`                  | ❌                | ❌         | ✅         |
+| `key`                  | ❌                | ✅         | ❌         |
 | `md5`                  | ✅                | ❌         | ❌         |
 
 ----

--- a/cloudpathlib/__init__.py
+++ b/cloudpathlib/__init__.py
@@ -4,6 +4,8 @@ from .azure.azblobclient import AzureBlobClient
 from .azure.azblobpath import AzureBlobPath
 from .cloudpath import CloudPath
 from .s3.s3client import S3Client
+from .gs.gspath import GSPath
+from .gs.gsclient import GSClient
 from .s3.s3path import S3Path
 
 
@@ -33,6 +35,8 @@ __all__ = [
     "CloudPath",
     "DirectoryNotEmpty",
     "InvalidPrefix",
+    "GSClient",
+    "GSPath",
     "MissingDependencies",
     "OverwriteDirtyFile",
     "OverwriteNewerLocal",

--- a/cloudpathlib/gs/__init__.py
+++ b/cloudpathlib/gs/__init__.py
@@ -1,0 +1,7 @@
+from .gsclient import GSClient
+from .gspath import GSPath
+
+__all__ = [
+    "GSClient",
+    "GSPath",
+]

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -1,0 +1,94 @@
+import os
+from pathlib import PurePosixPath
+from typing import Any, Dict, Iterable, Optional, Union
+
+from ..client import Client, register_client_class
+from ..cloudpath import implementation_registry
+from .gspath import GSPath
+
+try:
+    from google.cloud.storage import Client as Client_
+
+except ModuleNotFoundError:
+    implementation_registry["gs"].dependencies_loaded = False
+
+
+@register_client_class("gs")
+class GSClient(Client):
+    """Client for Google Cloud Storage."""
+
+    def __init__(
+        self,
+        local_cache_dir: Optional[Union[str, os.PathLike]] = None,
+    ):
+        """Class constructor.
+
+        Args:
+            local_cache_dir (Optional[Union[str, os.PathLike]]): Path to directory to use as cache
+                for downloaded files. If None, will use a temporary directory.
+        """
+
+        self.client = Client_()
+        super().__init__(local_cache_dir=local_cache_dir)
+
+    def _get_metadata(self, cloud_path: GSPath) -> Dict[str, Any]:
+        bucket = self.client.get_bucket(cloud_path.bucket)
+        blob = bucket.get_blob(cloud_path.key)
+
+        return blob.metadata or {}
+
+    def _download_file(
+        self, cloud_path: GSPath, local_path: Union[str, os.PathLike]
+    ) -> Union[str, os.PathLike]:
+        bucket = self.client.get_bucket(cloud_path.bucket)
+        blob = bucket.get_blob(cloud_path.key)
+
+        with open(local_path, "bw") as file_object:
+            self.client.download_blob_to_file(blob, file_object)
+        return local_path
+
+    def _is_file_or_dir(self, cloud_path: GSPath) -> Optional[str]:
+        # short-circuit the root-level bucket
+        if not cloud_path.key:
+            return "dir"
+
+        bucket = self.client.get_bucket(cloud_path.bucket)
+        blob = bucket.get_blob(cloud_path.key)
+
+        if blob.exists():
+            return "file"
+        else:
+            prefix = cloud_path.key
+            if prefix and not prefix.endswith("/"):
+                prefix += "/"
+
+            # not a file, see if it is a directory
+            f = self.client.list_blobs(bucket, max_results=1, prefix=prefix)
+
+            # at least one key with the prefix of the directory
+            if bool(list(f)):
+                return "dir"
+            else:
+                return None
+
+    def _exists(self, cloud_path: GSPath) -> bool:
+        return self._is_file_or_dir(cloud_path) in ["file", "dir"]
+
+    def _list_dir(self, cloud_path: GSPath, recursive=False) -> Iterable[GSPath]:
+        pass
+
+    def _move_file(self, src: GSPath, dst: GSPath) -> GSPath:
+        pass
+
+    def _remove(self, cloud_path: GSPath) -> None:
+        pass
+
+    def _upload_file(self, local_path: Union[str, os.PathLike], cloud_path: GSPath) -> GSPath:
+        bucket = self.client.bucket(cloud_path.bucket)
+        blob = bucket.blob(cloud_path.key)
+
+        blob.upload_from_filename(str(local_path))
+        return cloud_path
+
+
+GSClient.GSPath = GSClient.CloudPath  # type: ignore

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import os
-from os import PathLike
 from pathlib import PurePosixPath
 from typing import Any, Dict, Iterable, Optional, Union
 
@@ -22,45 +21,52 @@ class GSClient(Client):
 
     def __init__(
         self,
-        application_credentials: Optional[PathLike] = None,
+        application_credentials: Optional[Union[str, os.PathLike]] = None,
         credentials: Optional[Credentials] = None,
+        project: Optional[str] = None,
         storage_client: Optional[StorageClient] = None,
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,
     ):
-        """Class constructor. Sets up a [`Storage Client`](
-        https://googleapis.dev/python/storage/latest/client.html). Supports the following
-        authentication methods of `Storage Client`.
+        """Class constructor. Sets up a [`Storage
+        Client`](https://googleapis.dev/python/storage/latest/client.html).
+        Supports the following authentication methods of `Storage Client`.
 
-        - Environment variable `"GOOGLE_APPLICATION_CREDENTIALS"` containing a path to a JSON
-        credentials file for a Google service account. See [Authenticating as a Service Account](
-        https://cloud.google.com/docs/authentication/production).
-        - Account URL via `account_url`, authenticated either with an embedded SAS token, or with
-        credentials passed to `credentials`.
-        - Connection string via `connection_string`, authenticated either with an embedded SAS
-        token or with credentials passed to `credentials`.
+        - Environment variable `"GOOGLE_APPLICATION_CREDENTIALS"` containing a
+          path to a JSON credentials file for a Google service account. See
+          [Authenticating as a Service
+          Account](https://cloud.google.com/docs/authentication/production).
+        - File path to a JSON credentials file for a Google service account.
+        - OAuth2 Credentials object and a project name.
         - Instantiated and already authenticated `Storage Client`.
 
-        If multiple methods are used, priority order is reverse of list above (later in list takes
-        priority).
+        If multiple methods are used, priority order is reverse of list above
+        (later in list takes priority).
 
         Args:
-            project (Optional[str]): The project which the client acts on behalf of. Will be passed
-                when creating a topic. If not passed, falls back to the default inferred from the
-                environment.
-            credentials (Optional[Credentials]): The OAuth2 Credentials to use for this client. If not
-                passed (and if no _http object is passed), falls back to the default inferred from the
-                environment.
-            storage_client (Optional[StorageClient]):
+            application_credentials (Optional[Union[str, os.PathLike]]): Path to Google service
+                account credentials file.
+            credentials (Optional[Credentials]): The OAuth2 Credentials to use for this client.
+                See documentation for [`StorageClient`](
+                https://googleapis.dev/python/storage/latest/client.html).
+            project (Optional[str]): The project which the client acts on behalf of. See
+                documentation for [`StorageClient`](
+                https://googleapis.dev/python/storage/latest/client.html).
+            storage_client (Optional[StorageClient]): Instantiated [`StorageClient`](
+                https://googleapis.dev/python/storage/latest/client.html).
             local_cache_dir (Optional[Union[str, os.PathLike]]): Path to directory to use as cache
                 for downloaded files. If None, will use a temporary directory.
         """
 
         if storage_client is not None:
             self.client = storage_client
-        if application_credentials is not None:
+        elif credentials is not None:
+            self.client = StorageClient(credentials=credentials, project=project)
+        elif application_credentials is not None:
             self.client = StorageClient.from_service_account_json(application_credentials)
         else:
-            self.client = StorageClient(credentials=credentials)
+            self.client = StorageClient.from_service_account_json(
+                os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            )
 
         super().__init__(local_cache_dir=local_cache_dir)
 

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+from pathlib import PurePosixPath
 from typing import Any, Dict, Iterable, Optional, Union
 
 from ..client import Client, register_client_class
@@ -35,7 +36,11 @@ class GSClient(Client):
         bucket = self.client.get_bucket(cloud_path.bucket)
         blob = bucket.get_blob(cloud_path.blob)
 
-        return blob.metadata or {}
+        return {
+            "etag": blob.etag,
+            "size": blob.size,
+            "updated": blob.updated,
+        }
 
     def _download_file(
         self, cloud_path: GSPath, local_path: Union[str, os.PathLike]
@@ -55,7 +60,7 @@ class GSClient(Client):
         bucket = self.client.get_bucket(cloud_path.bucket)
         blob = bucket.get_blob(cloud_path.blob)
 
-        if blob.exists():
+        if blob is not None:
             return "file"
         else:
             prefix = cloud_path.blob
@@ -75,17 +80,56 @@ class GSClient(Client):
         return self._is_file_or_dir(cloud_path) in ["file", "dir"]
 
     def _list_dir(self, cloud_path: GSPath, recursive=False) -> Iterable[GSPath]:
-        pass
+        bucket = self.client.get_bucket(cloud_path.bucket)
+
+        prefix = cloud_path.blob
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+
+        yielded_dirs = set()
+
+        # NOTE: Not recursive may be slower than necessary since it just filters
+        #   the recursive implementation
+        for o in bucket.list_blobs(prefix=prefix):
+            # get directory from this path
+            for parent in PurePosixPath(o.name[len(prefix) :]).parents:
+
+                # if we haven't surfaced thei directory already
+                if parent not in yielded_dirs and str(parent) != ".":
+
+                    # skip if not recursive and this is beyond our depth
+                    if not recursive and "/" in str(parent):
+                        continue
+
+                    yield self.CloudPath(f"gs://{cloud_path.bucket}/{prefix}{parent}")
+                    yielded_dirs.add(parent)
+
+            # skip file if not recursive and this is beyond our depth
+            if not recursive and "/" in o.name[len(prefix) :]:
+                continue
+
+            yield self.CloudPath(f"gs://{cloud_path.bucket}/{o.name}")
 
     def _move_file(self, src: GSPath, dst: GSPath) -> GSPath:
         # just a touch, so "REPLACE" metadata
         if src == dst:
             bucket = self.client.bucket(src.bucket)
             blob = bucket.get_blob(src.blob)
-            blob.updated = datetime.utcnow().timestamp()
+
+            # See https://github.com/googleapis/google-cloud-python/issues/1185#issuecomment-431537214
+            if blob.metadata is None:
+                blob.metadata = {"updated": datetime.utcnow()}
+            else:
+                blob.metadata["updated"] = datetime.utcnow()
+            blob.patch()
 
         else:
-            pass
+            src_bucket = self.client.bucket(src.bucket)
+            dst_bucket = self.client.bucket(dst.bucket)
+
+            src_blob = src_bucket.get_blob(src.blob)
+            src_bucket.copy_blob(src_blob, dst_bucket, dst.blob)
+            src_blob.delete()
 
         return dst
 
@@ -94,7 +138,7 @@ class GSClient(Client):
             blobs = [b.blob for b in self._list_dir(cloud_path, recursive=True)]
             bucket = self.client.bucket(cloud_path.bucket)
             for blob in blobs:
-                blob.delete()
+                bucket.delete_blob(blob)
         elif self._is_file_or_dir(cloud_path) == "file":
             bucket = self.client.bucket(cloud_path.bucket)
             bucket.delete_blob(cloud_path.blob)

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -22,7 +22,7 @@ class GSClient(Client):
 
     def __init__(
         self,
-        application_credentials: PathLike,
+        application_credentials: Optional[PathLike] = None,
         credentials: Optional[Credentials] = None,
         storage_client: Optional[StorageClient] = None,
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -70,15 +70,18 @@ class GSClient(Client):
 
         super().__init__(local_cache_dir=local_cache_dir)
 
-    def _get_metadata(self, cloud_path: GSPath) -> Dict[str, Any]:
+    def _get_metadata(self, cloud_path: GSPath) -> Optional[Dict[str, Any]]:
         bucket = self.client.bucket(cloud_path.bucket)
         blob = bucket.get_blob(cloud_path.blob)
 
-        return {
-            "etag": blob.etag,
-            "size": blob.size,
-            "updated": blob.updated,
-        }
+        if blob is None:
+            return None
+        else:
+            return {
+                "etag": blob.etag,
+                "size": blob.size,
+                "updated": blob.updated,
+            }
 
     def _download_file(
         self, cloud_path: GSPath, local_path: Union[str, os.PathLike]

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -67,7 +67,7 @@ class GSClient(Client):
                 prefix += "/"
 
             # not a file, see if it is a directory
-            f = self.client.list_blobs(bucket, max_results=1, prefix=prefix)
+            f = bucket.list_blobs(max_results=1, prefix=prefix)
 
             # at least one key with the prefix of the directory
             if bool(list(f)):

--- a/cloudpathlib/gs/gspath.py
+++ b/cloudpathlib/gs/gspath.py
@@ -69,7 +69,7 @@ class GSPath(CloudPath):
         return self._no_prefix.split("/", 1)[0]
 
     @property
-    def key(self) -> str:
+    def blob(self) -> str:
         key = self._no_prefix_no_drive
 
         # key should never have starting slash for

--- a/cloudpathlib/gs/gspath.py
+++ b/cloudpathlib/gs/gspath.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
-from ..cloudpath import CloudPath, register_path_class
+from ..cloudpath import CloudPath, NoStat, register_path_class
 
 
 if TYPE_CHECKING:
@@ -43,6 +43,8 @@ class GSPath(CloudPath):
 
     def stat(self):
         meta = self.client._get_metadata(self)
+        if meta is None:
+            raise NoStat(f"No stats available for {self}; it may be a directory or not exist.")
 
         try:
             mtime = meta["updated"].timestamp()

--- a/cloudpathlib/gs/gspath.py
+++ b/cloudpathlib/gs/gspath.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+from ..cloudpath import CloudPath, register_path_class
+
+
+if TYPE_CHECKING:
+    from .gsclient import GSClient
+
+
+@register_path_class("gs")
+class GSPath(CloudPath):
+    cloud_prefix: str = "gs://"
+    client: "GSClient"
+
+    @property
+    def drive(self) -> str:
+        return self.bucket
+
+    def is_dir(self) -> bool:
+        return self.client._is_file_or_dir(self) == "dir"
+
+    def is_file(self) -> bool:
+        return self.client._is_file_or_dir(self) == "file"
+
+    def mkdir(self, parents=False, exist_ok=False):
+        # not possible to make empty directory on cloud storage
+        pass
+
+    def touch(self):
+        if self.exists():
+            self.client._move_file(self, self)
+        else:
+            tf = TemporaryDirectory()
+            p = Path(tf.name) / "empty"
+            p.touch()
+
+            self.client._upload_file(p, self)
+
+            tf.cleanup()
+
+    def stat(self):
+        meta = self.client._get_metadata(self)
+
+        try:
+            mtime = meta["updated"].timestamp()
+        except KeyError:
+            mtime = 0
+
+        return os.stat_result(
+            (
+                None,  # mode
+                None,  # ino
+                self.cloud_prefix,  # dev,
+                None,  # nlink,
+                None,  # uid,
+                None,  # gid,
+                meta.get("size", 0),  # size,
+                None,  # atime,
+                mtime,  # mtime,
+                None,  # ctime,
+            )
+        )
+
+    @property
+    def bucket(self) -> str:
+        return self._no_prefix.split("/", 1)[0]
+
+    @property
+    def key(self) -> str:
+        key = self._no_prefix_no_drive
+
+        # key should never have starting slash for
+        # use with google-cloud-storage, etc.
+        if key.startswith("/"):
+            key = key[1:]
+
+        return key
+
+    @property
+    def etag(self):
+        return self.client._get_metadata(self).get("etag")

--- a/docs/docs/api-reference/gsclient.md
+++ b/docs/docs/api-reference/gsclient.md
@@ -1,0 +1,3 @@
+# GSClient
+
+::: cloudpathlib.gs.gsclient.GSClient

--- a/docs/docs/api-reference/gspath.md
+++ b/docs/docs/api-reference/gspath.md
@@ -1,0 +1,3 @@
+# GSPath
+
+::: cloudpathlib.gs.gspath.GSPath

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -4,19 +4,21 @@ For standard use, we recommend using environment variables to authenticate with 
 
 `cloudpathlib` supports the standard environment variables used by each respective cloud service SDK.
 
-Cloud              | Environment Variables | SDK Documentation |
------------------- | --------------------- | ------------------|
-Amazon S3          | `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` <br /> _or_ <br /> `AWS_PROFILE` with credentials file | [Link](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables) |
-Azure Blob Storage | `AZURE_STORAGE_CONNECTION_STRING` | [Link](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python#copy-your-credentials-from-the-azure-portal) |
-
+Cloud                | Environment Variables | SDK Documentation |
+-------------------- | --------------------- | ------------------|
+Amazon S3            | `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` <br /> _or_ <br /> `AWS_PROFILE` with credentials file | [Link](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables) |
+Azure Blob Storage   | `AZURE_STORAGE_CONNECTION_STRING` | [Link](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python#copy-your-credentials-from-the-azure-portal) |
+Google Cloud Storage | `GOOGLE_APPLICATION_CREDENTIALS` | [Link](https://cloud.google.com/docs/authentication/production#passing_variable) |
+ 
 ## Advanced Use
 
 The communication between `cloudpathlib` and cloud storage services are handled by `Client` objects. Each cloud storage service has its own `Client` class implementation. See the linked API documentation pages for additional authentication options.
 
-Cloud              | Client                | API Documentation |
------------------- | --------------------- | ----------------- |
-Amazon S3          | `S3Client`            | [Link](../api-reference/s3client/) |
-Azure Blob Storage | `AzureBlobClient`     | [Link](../api-reference/azblobclient/) |
+Cloud                | Client                | API Documentation |
+-------------------- | --------------------- | ----------------- |
+Amazon S3            | `S3Client`            | [Link](../api-reference/s3client/) |
+Azure Blob Storage   | `AzureBlobClient`     | [Link](../api-reference/azblobclient/) |
+Google Cloud Storage | `GSClient`            | [Link](../api-reference/gsclient/) |
 
 A client object holds the authenticated connection with a cloud service, as well as the configuration for the [local cache](../caching/). When you create instantiate a cloud path instance for the first time, a default client object is created for the respective cloud service.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,6 +23,9 @@ nav:
       - Azure:
           - AzureBlobClient: "api-reference/azblobclient.md"
           - AzureBlobPath: "api-reference/azblobpath.md"
+      - GS:
+          - GSClient: "api-reference/gsclient.md"
+          - GSPath: "api-reference/gspath.md"
 
 markdown_extensions:
   - pymdownx.highlight

--- a/requirements/gs.txt
+++ b/requirements/gs.txt
@@ -1,0 +1,1 @@
+google-cloud-storage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,7 @@ def gs_rig(request, monkeypatch, assets_dir):
         # Mock cloud SDK
         monkeypatch.setattr(
             cloudpathlib.gs.gsclient,
-            "Client_",
+            "StorageClient",
             mocked_gsclient_class_factory(test_dir),
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from cloudpathlib import AzureBlobClient, AzureBlobPath, GSClient, GSPath, S3Cli
 import cloudpathlib.azure.azblobclient
 import cloudpathlib.s3.s3client
 from .mock_clients.mock_azureblob import mocked_client_class_factory
+from .mock_clients.mock_gs import mocked_client_class_factory as mocked_gsclient_class_factory
 from .mock_clients.mock_s3 import mocked_session_class_factory
 
 
@@ -137,8 +138,8 @@ def gs_rig(request, monkeypatch, assets_dir):
         # Mock cloud SDK
         monkeypatch.setattr(
             cloudpathlib.gs.gsclient,
-            "Client",
-            mocked_session_class_factory(test_dir),
+            "Client_",
+            mocked_gsclient_class_factory(test_dir),
         )
 
     rig = CloudProviderTestRig(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def gs_rig(request, monkeypatch, assets_dir):
 
     if os.getenv("USE_LIVE_GSCLOUD") == "1":
         # Set up test assets
-        bucket = google_storage.Client().get_bucket(drive)
+        bucket = google_storage.Client().bucket(drive)
         test_files = [
             f for f in assets_dir.glob("**/*") if f.is_file() and f.name not in UPLOAD_IGNORE_LIST
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ def gs_rig(request, monkeypatch, assets_dir):
     drive = os.getenv("LIVE_GS_BUCKET", "bucket")
     test_dir = create_test_dir_name(request)
 
-    if os.getenv("USE_LIVE_GSCLOUD") == "1":
+    if os.getenv("USE_LIVE_CLOUD") == "1":
         # Set up test assets
         bucket = google_storage.Client().bucket(drive)
         test_files = [
@@ -152,7 +152,7 @@ def gs_rig(request, monkeypatch, assets_dir):
 
     rig.client_class._default_client = None  # reset default client
 
-    if os.getenv("USE_LIVE_GSCLOUD") == "1":
+    if os.getenv("USE_LIVE_CLOUD") == "1":
         # Clean up test dir
         for blob in bucket.list_blobs(prefix=test_dir):
             blob.delete()

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+import shutil
+from tempfile import TemporaryDirectory
+
+from .utils import delete_empty_parents_up_to_root
+
+TEST_ASSETS = Path(__file__).parent.parent / "assets"
+
+
+def mocked_client_class_factory(test_dir: str):
+    class MockClient:
+        def __init__(self, *args, **kwargs):
+            # copy test assets for reference in tests without affecting assets
+            self.tmp = TemporaryDirectory()
+            self.tmp_path = Path(self.tmp.name) / "test_case_copy"
+            shutil.copytree(TEST_ASSETS, self.tmp_path / test_dir)
+
+        def __del__(self):
+            self.tmp.cleanup()
+
+        def get_bucket(self, bucket):
+            return MockBucket(self.tmp_path)
+
+    return MockClient
+
+
+class MockBlob:
+    def __init__(self, root, name):
+        self.bucket = root
+        self.name = str(name)
+        self.metadata = None
+
+    def delete(self):
+        path = self.bucket / self.name
+        path.unlink()
+        delete_empty_parents_up_to_root(path=path, root=self.bucket)
+
+    def download_to_filename(self, filename):
+        from_path = self.bucket / self.name
+        to_path = Path(filename)
+        to_path.write_bytes(from_path.read_bytes())
+
+    def patch(self):
+        if "updated" in self.metadata:
+            (self.bucket / self.name).touch()
+
+    def upload_from_filename(self, filename):
+        data = Path(filename).read_bytes()
+        path = self.bucket / self.name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    @property
+    def etag(self):
+        return "etag"
+
+    @property
+    def size(self):
+        path = self.bucket / self.name
+        return path.stat().st_size
+
+    @property
+    def updated(self):
+        path = self.bucket / self.name
+        return datetime.fromtimestamp(path.stat().st_mtime)
+
+
+class MockBucket:
+    def __init__(self, name):
+        self.name = name
+
+    def blob(self, blob):
+        return MockBlob(self.name, blob)
+
+    def copy_blob(self, blob, destination_bucket, new_name):
+        data = (self.name / blob.name).read_bytes()
+        (destination_bucket.name / new_name).write_bytes(data)
+
+    def get_blob(self, blob):
+        if (self.name / blob).is_file():
+            return MockBlob(self.name, blob)
+        else:
+            return None
+
+    def list_blobs(self, max_results=None, prefix=None):
+        path = self.name if prefix is None else self.name / prefix
+        items = [
+            MockBlob(self.name, f.relative_to(self.name))
+            for f in path.glob("**/*")
+            if f.is_file() and not f.name.startswith(".")
+        ]
+        return MockHTTPIterator(items, max_results)
+
+
+class MockHTTPIterator:
+    def __init__(self, items, max_results):
+        self.items = items
+        self.max_results = max_results
+
+    def __iter__(self):
+        if self.max_results is None:
+            return iter(self.items)
+        else:
+            return iter(self.items[: self.max_results])

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -16,6 +16,10 @@ def mocked_client_class_factory(test_dir: str):
             self.tmp_path = Path(self.tmp.name) / "test_case_copy"
             shutil.copytree(TEST_ASSETS, self.tmp_path / test_dir)
 
+        @classmethod
+        def from_service_account_json(cls, *args, **kwargs):
+            return cls()
+
         def __del__(self):
             self.tmp.cleanup()
 

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -75,7 +75,9 @@ class MockBucket:
 
     def copy_blob(self, blob, destination_bucket, new_name):
         data = (self.name / blob.name).read_bytes()
-        (destination_bucket.name / new_name).write_bytes(data)
+        dst = destination_bucket.name / new_name
+        dst.parent.mkdir(exist_ok=True, parents=True)
+        dst.write_bytes(data)
 
     def get_blob(self, blob):
         if (self.name / blob).is_file():

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 import shutil
 from tempfile import TemporaryDirectory
 
@@ -19,7 +19,7 @@ def mocked_client_class_factory(test_dir: str):
         def __del__(self):
             self.tmp.cleanup()
 
-        def get_bucket(self, bucket):
+        def bucket(self, bucket):
             return MockBucket(self.tmp_path)
 
     return MockClient

--- a/tests/test_gs_specific.py
+++ b/tests/test_gs_specific.py
@@ -1,0 +1,11 @@
+from cloudpathlib import GSPath
+
+
+def test_gspath_properties(gs_rig):
+    p = GSPath(f"gs://{gs_rig.drive}")
+    assert p.blob == ""
+    assert p.bucket == gs_rig.drive
+
+    p2 = GSPath(f"gs://{gs_rig.drive}/")
+    assert p2.blob == ""
+    assert p2.bucket == gs_rig.drive


### PR DESCRIPTION
Google Cloud Storage support with `GSClient` and `GSPath` subclasses.

Features:

- Implements `GSClient` and `GSPath` as subclasses of `Client` and `CloudPath` respectively.
- Adds `gs` as an extra for pip installation with separate requirements.txt.
- Creates `gs_rig` test configuration and adds to `rig` for test suite.
- Creates mock clients for testing `GSClient` and `GSPath` without internet.
- Creates tests for `GSClient` and `GSPath` specific features.
- Updates documentation to show that `gs` is a pip extra for Google Cloud Storage support.
- Updates REAMDE table indicating availability of GCS.

The GitHub Actions `tests` workflow has been updated to include `GOOGLE_APPLICATION_CREDENTIALS` and `LIVE_GS_BUCKET` environment variables for GitHub Secrets usage. However, it seems, from the [Google Service Account Authentication documentation](https://cloud.google.com/docs/authentication/production), that authentication cannot happen with credentials in environment variables directly. Rather the environment variable `GOOGLE_APPLICATION_CREDENTIALS` must point to a JSON file with the authentication credentials. I don't know of a secure way to resolve this issue with GitHub Secrets.

Resolves #25.