### PR TITLE
Fix NameError if google storage not installed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## v0.2.1 (2020-01-25)
+
+- Fixed bug where a NameError was raised if the Google Stroage dependencies were not installed (even if using a different storage provider).
+
+
 ## v0.2.0 (2020-01-23)
 
 - Added support for Google Cloud Storage. Instantiate with URIs prefixed by `gs://` or explicitly using the `GSPath` class. ([#113](https://github.com/drivendataorg/cloudpathlib/pull/113) thanks to [@wolfgangwazzlestrauss](https://github.com/wolfgangwazzlestrauss))

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -1,19 +1,17 @@
 from datetime import datetime
 import os
 from pathlib import PurePosixPath
-from typing import Any, Dict, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING, Union
 
 from ..client import Client, register_client_class
 from ..cloudpath import implementation_registry
 from .gspath import GSPath
 
 try:
-    from google.auth.credentials import Credentials  # noqa: F401
-    from google.cloud.storage import Client as StorageClient
+    if TYPE_CHECKING:
+        from google.auth.credentials import Credentials
 
-    # for flake8 + typechecking
-    import google.auth.credentials
-    import google.cloud.storage
+    from google.cloud.storage import Client as StorageClient
 
 except ModuleNotFoundError:
     implementation_registry["gs"].dependencies_loaded = False
@@ -26,9 +24,9 @@ class GSClient(Client):
     def __init__(
         self,
         application_credentials: Optional[Union[str, os.PathLike]] = None,
-        credentials: Optional["google.auth.credentials.Credentials"] = None,
+        credentials: Optional["Credentials"] = None,
         project: Optional[str] = None,
-        storage_client: Optional["google.cloud.storage.Client"] = None,
+        storage_client: Optional["StorageClient"] = None,
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,
     ):
         """Class constructor. Sets up a [`Storage

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -8,8 +8,12 @@ from ..cloudpath import implementation_registry
 from .gspath import GSPath
 
 try:
-    from google.auth.credentials import Credentials
+    from google.auth.credentials import Credentials  # noqa: F401
     from google.cloud.storage import Client as StorageClient
+
+    # for flake8 + typechecking
+    import google.auth.credentials
+    import google.cloud.storage
 
 except ModuleNotFoundError:
     implementation_registry["gs"].dependencies_loaded = False
@@ -22,9 +26,9 @@ class GSClient(Client):
     def __init__(
         self,
         application_credentials: Optional[Union[str, os.PathLike]] = None,
-        credentials: Optional[Credentials] = None,
+        credentials: Optional["google.auth.credentials.Credentials"] = None,
         project: Optional[str] = None,
-        storage_client: Optional[StorageClient] = None,
+        storage_client: Optional["google.cloud.storage.Client"] = None,
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,
     ):
         """Class constructor. Sets up a [`Storage

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.2.0",
+    version="0.2.1",
 )


### PR DESCRIPTION
 - Change type hints to strings instead of imported types
 - Add imports that make flake8 of the type hints happy

Bump version and history for release.

Closes #115 
