### PR TITLE
Append filename to destination if source is file

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -577,7 +577,7 @@ class CloudPath(metaclass=CloudPathMeta):
         destination = Path(destination)
         if self.is_file():
             if destination.is_dir():
-                destination = destination.joinpath(self.name)
+                destination = destination / self.name
             self.client._download_file(self, destination)
         else:
             destination.mkdir(exist_ok=True)

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -576,6 +576,8 @@ class CloudPath(metaclass=CloudPathMeta):
     def download_to(self, destination: Union[str, os.PathLike]):
         destination = Path(destination)
         if self.is_file():
+            if destination.is_dir():
+                destination = destination.joinpath(self.name)
             self.client._download_file(self, destination)
         else:
             destination.mkdir(exist_ok=True)

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -85,6 +85,9 @@ def test_file_read_writes(rig, tmp_path):
 
     dl_dir = tmp_path / "directory"
     dl_dir.mkdir(parents=True, exist_ok=True)
+    assert not dl_dir.joinpath(p.name).exists()
+    p.download_to(dl_dir)
+    assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
     p3.download_to(dl_dir)
     cloud_rel_paths = sorted(
         # CloudPath("prefix://drive/dir/file.txt")._no_prefix_no_drive = "/dir/file.txt"

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -100,9 +100,7 @@ def test_cloud_path_download_to(rig, tmp_path):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     dl_dir = tmp_path
     assert not (dl_dir / p.name).exists()
-    print(list(dl_dir.iterdir()))
     p.download_to(dl_dir)
-    print(list(dl_dir.iterdir()))
     assert (dl_dir / p.name).is_file()
 
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -96,6 +96,16 @@ def test_file_read_writes(rig, tmp_path):
     assert cloud_rel_paths == dled_rel_paths
 
 
+def test_cloud_path_download_to(rig, tmp_path):
+    p = rig.create_cloud_path("dir_0/file0_0.txt")
+    dl_dir = tmp_path
+    assert not dl_dir.joinpath(p.name).exists()
+    print(list(dl_dir.iterdir()))
+    p.download_to(dl_dir)
+    print(list(dl_dir.iterdir()))
+    assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
+
+
 def test_fspath(rig):
     p = rig.create_cloud_path("dir_0")
     assert os.fspath(p) == p.fspath

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -85,9 +85,6 @@ def test_file_read_writes(rig, tmp_path):
 
     dl_dir = tmp_path / "directory"
     dl_dir.mkdir(parents=True, exist_ok=True)
-    assert not dl_dir.joinpath(p.name).exists()
-    p.download_to(dl_dir)
-    assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
     p3.download_to(dl_dir)
     cloud_rel_paths = sorted(
         # CloudPath("prefix://drive/dir/file.txt")._no_prefix_no_drive = "/dir/file.txt"
@@ -97,6 +94,14 @@ def test_file_read_writes(rig, tmp_path):
         [str(PurePosixPath(p.relative_to(dl_dir))) for p in dl_dir.glob("**/*")]
     )
     assert cloud_rel_paths == dled_rel_paths
+
+
+def test_cloud_path_download_to(rig, tmp_path):
+    p = rig.create_cloud_path("dir_0/file0_0.txt")
+    dl_dir = tmp_path / "directory"
+    assert not dl_dir.joinpath(p.name).exists()
+    p.download_to(dl_dir)
+    assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
 
 
 def test_fspath(rig):

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -99,11 +99,11 @@ def test_file_read_writes(rig, tmp_path):
 def test_cloud_path_download_to(rig, tmp_path):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     dl_dir = tmp_path
-    assert not dl_dir.joinpath(p.name).exists()
+    assert not (dl_dir / p.name).exists()
     print(list(dl_dir.iterdir()))
     p.download_to(dl_dir)
     print(list(dl_dir.iterdir()))
-    assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
+    assert (dl_dir / p.name).is_file()
 
 
 def test_fspath(rig):

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -96,15 +96,6 @@ def test_file_read_writes(rig, tmp_path):
     assert cloud_rel_paths == dled_rel_paths
 
 
-def test_cloud_path_download_to(rig, tmp_path):
-    p = rig.create_cloud_path("dir_0/file0_0.txt")
-    dl_dir = tmp_path
-    assert not dl_dir.joinpath(p.name).exists()
-    p.download_to(dl_dir)
-    assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
-    os.remove(dl_dir.joinpath(p.name))
-
-
 def test_fspath(rig):
     p = rig.create_cloud_path("dir_0")
     assert os.fspath(p) == p.fspath

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -98,7 +98,7 @@ def test_file_read_writes(rig, tmp_path):
 
 def test_cloud_path_download_to(rig, tmp_path):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
-    dl_dir = tmp_path / "directory"
+    dl_dir = tmp_path
     assert not dl_dir.joinpath(p.name).exists()
     print(list(dl_dir.iterdir()))
     p.download_to(dl_dir)

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -100,10 +100,9 @@ def test_cloud_path_download_to(rig, tmp_path):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     dl_dir = tmp_path
     assert not dl_dir.joinpath(p.name).exists()
-    print(list(dl_dir.iterdir()))
     p.download_to(dl_dir)
-    print(list(dl_dir.iterdir()))
     assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
+    os.remove(dl_dir.joinpath(p.name))
 
 
 def test_fspath(rig):

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -100,7 +100,9 @@ def test_cloud_path_download_to(rig, tmp_path):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     dl_dir = tmp_path / "directory"
     assert not dl_dir.joinpath(p.name).exists()
+    print(list(dl_dir.iterdir()))
     p.download_to(dl_dir)
+    print(list(dl_dir.iterdir()))
     assert dl_dir.joinpath(p.name).exists() & dl_dir.joinpath(p.name).is_file()
 
 


### PR DESCRIPTION
Fixes #74.

The `CloudPath.download_to` method adds the filename to the destination path if the cloud source is a file and the destination is a folder.
