### PR TITLE
Split up CI workflows

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,42 @@
+name: docs-preview
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build and deploy docs website preview
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Build documentation
+        run: |
+          make docs
+
+      - name: Deploy site preview to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./docs/site"
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+          overwrites-pull-request-comment: true
+          alias: deploy-preview-${{ github.event.number }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/tests-live.yml
+++ b/.github/workflows/tests-live.yml
@@ -1,0 +1,45 @@
+name: tests-live
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    # Run every Sunday
+    - cron: "0 0 * * 0"
+
+jobs:
+  build:
+    name: Run live tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Run live tests
+        run: |
+          make test-live-cloud
+        env:
+          LIVE_AZURE_CONTAINER: ${{ secrets.LIVE_AZURE_CONTAINER }}
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
+          LIVE_GS_BUCKET: ${{ secrets.LIVE_GS_BUCKET }}
+          LIVE_S3_BUCKET: ${{ secrets.LIVE_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,25 +38,6 @@ jobs:
         run: |
           make test
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Run live tests
-        run: |
-          make test-live-cloud
-        env:
-          LIVE_AZURE_CONTAINER: ${{ secrets.LIVE_AZURE_CONTAINER }}
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
-          LIVE_GS_BUCKET: ${{ secrets.LIVE_GS_BUCKET }}
-          LIVE_S3_BUCKET: ${{ secrets.LIVE_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        if: matrix.python-version == 3.8
-
       - name: Build distribution and test installation
         shell: bash
         run: |
@@ -64,33 +45,9 @@ jobs:
           python -m pip install dist/cloudpathlib-*.whl --no-deps --force-reinstall
           python -m pip install dist/cloudpathlib-*.tar.gz --no-deps --force-reinstall
 
-      - name: Test building documentation
-        run: |
-          make docs
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
-
-      - name: Deploy site preview to Netlify
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
-        uses: nwtgck/actions-netlify@v1.1
-        with:
-          publish-dir: "./docs/site"
-          production-deploy: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
-          enable-commit-comment: false
-          overwrites-pull-request-comment: true
-          alias: deploy-preview-${{ github.event.number }}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
-
       - name: Upload coverage to codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CLOUDPATHLIB_CODECOV_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8 }}


### PR DESCRIPTION
This PR splits up the `tests` CI workflow, separating out the live tests into `tests-live` and the docs website preview into `docs-preview`. Those two things require credentials in the repo secrets, which aren't available to PRs from forks for reasonable security reasons. This way, we can run the mocked tests on the full build matrix and see if those builds pass, without the live tests or docs preview interfering. 

#123 shows a demo of this from a forked repo on my user account. 

### Alternative: Keep in one workflow, turn off fast-fail

An alternative to this approach is turning off fast-fail. The multiple workflow approach has the advantage of better visibility into the mocked tests success/fail states, as well as the more efficient compute use that comes from keeping fast-fail. 

### Bad Alternative: Make secrets available to forks

This is a bad idea because people can steal our credentials. 
