### PR TITLE
Rich comparison operators, hashing fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## v0.3.1 (Unreleased)
+
+- Added rich comparison operator support to cloud paths, which means you can now use them with `sorted`.
+
 ## v0.3.0 (2021-01-29)
 
 - Added a new module `cloudpathlib.local` with utilities for mocking cloud paths in tests. The module has "Local" substitute classes that use the local filesystem in place of cloud storage. See the new documentation article ["Testing code that uses cloudpathlib"](https://cloudpathlib.drivendata.org/testing_mocked_cloudpathlib/) to learn more about how to use them. ([#107](https://github.com/drivendataorg/cloudpathlib/pull/107))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## v0.3.1 (Unreleased)
 
 - Added rich comparison operator support to cloud paths, which means you can now use them with `sorted`.
+- Fixed bug where `hash(...)` of a cloud path was not consistent with the equality operator.
 
 ## v0.3.0 (2021-01-29)
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -205,18 +205,17 @@ class CloudPath(metaclass=CloudPathMeta):
 
         return valid
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}('{self}')"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._str
 
-    def __hash__(self):
-        # use repr for type and resolved path to assess if paths are the same
-        return hash(self.__repr__)
+    def __hash__(self) -> int:
+        return hash((type(self).__name__, str(self)))
 
-    def __eq__(self, other: Any):
-        return repr(self) == repr(other)
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, type(self)) and str(self) == str(other)
 
     def __fspath__(self):
         if self.is_file():

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -223,6 +223,26 @@ class CloudPath(metaclass=CloudPathMeta):
             self._refresh_cache(force_overwrite_from_cloud=False)
         return str(self._local)
 
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.parts < other.parts
+
+    def __le__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.parts <= other.parts
+
+    def __gt__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.parts > other.parts
+
+    def __ge__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.parts >= other.parts
+
     # ====================== NOT IMPLEMENTED ======================
     # absolute - no cloud equivalent; all cloud paths are absolute already
     # as_posix - no cloud equivalent; not needed since we assume url separator

--- a/tests/test_cloudpath_manipulation.py
+++ b/tests/test_cloudpath_manipulation.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_joins(rig):
     assert rig.create_cloud_path("a/b/c/d").name == "d"
     assert rig.create_cloud_path("a/b/c/d.file").name == "d.file"
@@ -45,3 +48,39 @@ def test_joins(rig):
         "c",
         "d",
     )
+
+
+def test_sorting(rig):
+    assert rig.create_cloud_path("a/b/c") < rig.create_cloud_path("a/c/b")
+    assert rig.create_cloud_path("a/b/c") <= rig.create_cloud_path("a/c/b")
+    assert not rig.create_cloud_path("a/b/c") > rig.create_cloud_path("a/c/b")
+    assert not rig.create_cloud_path("a/b/c") >= rig.create_cloud_path("a/c/b")
+
+    assert rig.create_cloud_path("a/c/b") > rig.create_cloud_path("a/b/c")
+    assert rig.create_cloud_path("a/c/b") >= rig.create_cloud_path("a/b/c")
+    assert not rig.create_cloud_path("a/c/b") < rig.create_cloud_path("a/b/c")
+    assert not rig.create_cloud_path("a/c/b") <= rig.create_cloud_path("a/b/c")
+
+    assert rig.create_cloud_path("a/b/c") <= rig.create_cloud_path("a/b/c")
+    assert rig.create_cloud_path("a/c/b") >= rig.create_cloud_path("a/c/b")
+
+    assert sorted(
+        [
+            rig.create_cloud_path("a/c/b"),
+            rig.create_cloud_path("a/b/c"),
+            rig.create_cloud_path("d/e/f"),
+        ]
+    ) == [
+        rig.create_cloud_path("a/b/c"),
+        rig.create_cloud_path("a/c/b"),
+        rig.create_cloud_path("d/e/f"),
+    ]
+
+    with pytest.raises(TypeError):
+        assert rig.create_cloud_path("a/b/c") < str(rig.create_cloud_path("a/b/c"))
+    with pytest.raises(TypeError):
+        assert rig.create_cloud_path("a/b/c") <= str(rig.create_cloud_path("a/b/c"))
+    with pytest.raises(TypeError):
+        assert rig.create_cloud_path("a/b/c") > str(rig.create_cloud_path("a/b/c"))
+    with pytest.raises(TypeError):
+        assert rig.create_cloud_path("a/b/c") >= str(rig.create_cloud_path("a/b/c"))

--- a/tests/test_cloudpath_manipulation.py
+++ b/tests/test_cloudpath_manipulation.py
@@ -50,19 +50,35 @@ def test_joins(rig):
     )
 
 
-def test_sorting(rig):
-    assert rig.create_cloud_path("a/b/c") < rig.create_cloud_path("a/c/b")
-    assert rig.create_cloud_path("a/b/c") <= rig.create_cloud_path("a/c/b")
-    assert not rig.create_cloud_path("a/b/c") > rig.create_cloud_path("a/c/b")
-    assert not rig.create_cloud_path("a/b/c") >= rig.create_cloud_path("a/c/b")
+def test_equality(rig):
+    assert rig.create_cloud_path("a/b/foo") == rig.create_cloud_path("a/b/foo")
+    assert hash(rig.create_cloud_path("a/b/foo")) == hash(rig.create_cloud_path("a/b/foo"))
 
-    assert rig.create_cloud_path("a/c/b") > rig.create_cloud_path("a/b/c")
-    assert rig.create_cloud_path("a/c/b") >= rig.create_cloud_path("a/b/c")
-    assert not rig.create_cloud_path("a/c/b") < rig.create_cloud_path("a/b/c")
-    assert not rig.create_cloud_path("a/c/b") <= rig.create_cloud_path("a/b/c")
+    assert rig.create_cloud_path("a/b/foo") != rig.create_cloud_path("a/b/bar")
+    assert hash(rig.create_cloud_path("a/b/foo")) != hash(rig.create_cloud_path("a/b/bar"))
+
+    cp = rig.create_cloud_path("a/b/foo")
+    assert cp != str(cp)
+    assert cp != repr(cp)
+    assert hash(cp) != hash(str(cp))
+    assert hash(cp) != hash(repr(cp))
+
+
+def test_sorting(rig):
+    cp1 = rig.create_cloud_path("a/b/c")
+    cp2 = rig.create_cloud_path("a/c/b")
+    assert cp1 < cp2
+    assert cp1 <= cp2
+    assert not cp1 > cp2
+    assert not cp1 >= cp2
+
+    assert cp2 > cp1
+    assert cp2 >= cp1
+    assert not cp2 < cp1
+    assert not cp2 <= cp1
 
     assert rig.create_cloud_path("a/b/c") <= rig.create_cloud_path("a/b/c")
-    assert rig.create_cloud_path("a/c/b") >= rig.create_cloud_path("a/c/b")
+    assert rig.create_cloud_path("a/b/c") >= rig.create_cloud_path("a/b/c")
 
     assert sorted(
         [
@@ -77,10 +93,10 @@ def test_sorting(rig):
     ]
 
     with pytest.raises(TypeError):
-        assert rig.create_cloud_path("a/b/c") < str(rig.create_cloud_path("a/b/c"))
+        assert cp1 < str(cp1)
     with pytest.raises(TypeError):
-        assert rig.create_cloud_path("a/b/c") <= str(rig.create_cloud_path("a/b/c"))
+        assert cp1 <= str(cp1)
     with pytest.raises(TypeError):
-        assert rig.create_cloud_path("a/b/c") > str(rig.create_cloud_path("a/b/c"))
+        assert cp1 > str(cp1)
     with pytest.raises(TypeError):
-        assert rig.create_cloud_path("a/b/c") >= str(rig.create_cloud_path("a/b/c"))
+        assert cp1 >= str(cp1)


### PR DESCRIPTION
- Adds rich comparison operators, which enables use with `sorted`
- Fixes a bug with `__hash__`. This was previously hashing the bound method `__repr__` (and not the string output of `__repr__`) and so gave a unique hash for every instance of a cloud path. 