### PR TITLE
Big documentation update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ docs/docs/command-reference/*.md
 
 # always built by `make docs`
 docs/docs/index.md
+docs/docs/changelog.md
 
 ## GitHub Python .gitignore ##
 # https://github.com/github/gitignore/blob/master/Python.gitignore

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,18 +2,18 @@
 
 ## v0.4.0 (Unreleased)
 
-- Added rich comparison operator support to cloud paths, which means you can now use them with `sorted`.
-- Added polymorphic class `AnyPath` which creates a cloud path or `pathlib.Path` instance appropriately for an input filepath. See new [documentation](http://https://cloudpathlib.drivendata.org/anypath-polymorphism/) for details and example usage.
-- Added integration with [Pydantic](https://pydantic-docs.helpmanual.io/). See new [documentation](http://https://cloudpathlib.drivendata.org/integrations/#pydantic) for details and example usage.
-- Exceptions:
+- Added rich comparison operator support to cloud paths, which means you can now use them with `sorted`. ([#129](https://github.com/drivendataorg/cloudpathlib/pull/129))
+- Added polymorphic class `AnyPath` which creates a cloud path or `pathlib.Path` instance appropriately for an input filepath. See new [documentation](http://https://cloudpathlib.drivendata.org/anypath-polymorphism/) for details and example usage. ([#130](https://github.com/drivendataorg/cloudpathlib/pull/130))
+- Added integration with [Pydantic](https://pydantic-docs.helpmanual.io/). See new [documentation](http://https://cloudpathlib.drivendata.org/integrations/#pydantic) for details and example usage. ([#130](https://github.com/drivendataorg/cloudpathlib/pull/130))
+- Exceptions: ([#131](https://github.com/drivendataorg/cloudpathlib/pull/131))
     - Changed all custom `cloudpathlib` exceptions to be located in new `cloudpathlib.exceptions` module.
     - Changed all custom `cloudpathlib` exceptions to subclass from new base `CloudPathException`. This allows for easy catching of any custom exception from `cloudpathlib`.
     - Changed all custom exceptions names to end with `Error` as recommended by [PEP 8](https://www.python.org/dev/peps/pep-0008/#exception-names).
     - Changed various functions to throw new `CloudPathFileExistsError`, `CloudPathIsADirectoryError` or `CloudPathNotADirectoryError` exceptions instead of a generic `ValueError`.
     - Removed exception exports from the root `cloudpathlib` package namespace. Import from `cloudpathlib.exceptions` instead if needed.
-- Fixed bug where `hash(...)` of a cloud path was not consistent with the equality operator.
-- Fixed `AzureBlobClient` instantiation to throw new error `MissingCredentialsError` when no credentials are provided, instead of `AttributeError`. `LocalAzureBlobClient` has also been changed to accordingly error under those conditions.
-- Fixed `GSClient` to instantiate as anonymous with public access only when instantiated with no credentials, instead of erroring.
+- Fixed bug where `hash(...)` of a cloud path was not consistent with the equality operator. ([#129](https://github.com/drivendataorg/cloudpathlib/pull/129))
+- Fixed `AzureBlobClient` instantiation to throw new error `MissingCredentialsError` when no credentials are provided, instead of `AttributeError`. `LocalAzureBlobClient` has also been changed to accordingly error under those conditions. ([#131](https://github.com/drivendataorg/cloudpathlib/pull/131))
+- Fixed `GSClient` to instantiate as anonymous with public access only when instantiated with no credentials, instead of erroring. ([#131](https://github.com/drivendataorg/cloudpathlib/pull/131))
 
 ## v0.3.0 (2021-01-29)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# History
+# cloudpathlib Changelog
 
 ## v0.4.0 (Unreleased)
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ dist: clean ## builds source and wheel package
 	ls -l dist
 
 docs: clean-docs
-	sed 's|docs/docs/logo.svg|logo.svg|g' README.md > docs/docs/index.md
+	sed 's|https://raw.githubusercontent.com/drivendataorg/cloudpathlib/master/docs/docs/logo.svg|logo.svg|g' README.md > docs/docs/index.md
 	cd docs && mkdocs build
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ dist: clean ## builds source and wheel package
 
 docs: clean-docs
 	sed 's|https://raw.githubusercontent.com/drivendataorg/cloudpathlib/master/docs/docs/logo.svg|logo.svg|g' README.md > docs/docs/index.md
+	cp HISTORY.md docs/docs/changelog.md
 	cd docs && mkdocs build
 
 format:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > Our goal is to be the meringue of file management libraries: the subtle sweetness of `pathlib` working in harmony with the ethereal lightness of the cloud.
 
-A library that implements (nearly all) of the `pathlib.Path` methods for URIs for different cloud storage services.
+A Python library with classes that mimic `pathlib.Path`'s interface for URIs from different cloud storage services.
 
 ```python
 with CloudPath("s3://bucket/filename.txt").open("w+") as f:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](https://raw.githubusercontent.com/drivendataorg/cloudpathlib/master/docs/docs/logo.svg)
 
+<h1></h1>
+
 [![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://cloudpathlib.drivendata.org/)
 [![PyPI](https://img.shields.io/pypi/v/cloudpathlib.svg)](https://pypi.org/project/cloudpathlib/)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/cloudpathlib.svg)](https://anaconda.org/conda-forge/cloudpathlib)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](docs/docs/logo.svg)
+![](https://raw.githubusercontent.com/drivendataorg/cloudpathlib/master/docs/docs/logo.svg)
 
 [![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://cloudpathlib.drivendata.org/)
 [![PyPI](https://img.shields.io/pypi/v/cloudpathlib.svg)](https://pypi.org/project/cloudpathlib/)

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -48,7 +48,8 @@ class AzureBlobClient(Client):
         https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient?view=azure-python).
 
         If multiple methods are used, priority order is reverse of list above (later in list takes
-        priority).
+        priority). If no methods are used, a [`MissingCredentialsError`][cloudpathlib.exceptions.MissingCredentialsError]
+        exception will be raised raised.
 
         Args:
             account_url (Optional[str]): The URL to the blob storage account, optionally

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -19,7 +19,11 @@ except ModuleNotFoundError:
 
 @register_client_class("azure")
 class AzureBlobClient(Client):
-    """Client for Azure Blob Storage."""
+    """Client class for Azure Blob Storage which handles authentication with Azure for
+    [`AzureBlobPath`](../azblobpath/) instances. See documentation for the
+    [`__init__` method][cloudpathlib.azure.azblobclient.AzureBlobClient.__init__] for detailed
+    authentication options.
+    """
 
     def __init__(
         self,

--- a/cloudpathlib/azure/azblobpath.py
+++ b/cloudpathlib/azure/azblobpath.py
@@ -17,6 +17,19 @@ if TYPE_CHECKING:
 
 @register_path_class("azure")
 class AzureBlobPath(CloudPath):
+    """Class for representing and operating on Azure Blob Storage URIs, in the style of the Python
+    standard library's [`pathlib` module](https://docs.python.org/3/library/pathlib.html).
+    Instances represent a path in Blob Storage with filesystem path semantics, and convenient
+    methods allow for basic operations like joining, reading, writing, iterating over contents,
+    etc. This class almost entirely mimics the [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
+    interface, so most familiar properties and methods should be available and behave in the
+    expected way.
+
+    The [`AzureBlobClient`](../azblobclient/) class handles authentication with Azure. If a
+    client instance is not explicitly specified on `AzureBlobPath` instantiation, a default client
+    is used. See `AzureBlobClient`'s documentation for more details.
+    """
+
     cloud_prefix: str = "az://"
     client: "AzureBlobClient"
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -123,6 +123,20 @@ class CloudPathMeta(abc.ABCMeta):
 
 # Abstract base class
 class CloudPath(metaclass=CloudPathMeta):
+    """Base class for cloud storage file URIs, in the style of the Python standard library's
+    [`pathlib` module](https://docs.python.org/3/library/pathlib.html). Instances represent a path
+    in cloud storage with filesystem path semantics, and convenient methods allow for basic
+    operations like joining, reading, writing, iterating over contents, etc. `CloudPath` almost
+    entirely mimics the [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
+    interface, so most familiar properties and methods should be available and behave in the
+    expected way.
+
+    Analogous to the way `pathlib.Path` works, instantiating `CloudPath` will instead create an
+    instance of an appropriate subclass that implements a particular cloud storage service, such as
+    [`S3Path`](../s3path). This dispatching behavior is based on the URI scheme part of a cloud
+    storage URI (e.g., `"s3://"`).
+    """
+
     _cloud_meta: CloudImplementation
     cloud_prefix: str
 

--- a/cloudpathlib/exceptions.py
+++ b/cloudpathlib/exceptions.py
@@ -1,3 +1,9 @@
+"""This module contains all custom exceptions in the `cloudpathlib` library. All exceptions
+subclass the [`CloudPathException` base exception][cloudpathlib.exceptions.CloudPathException] to
+facilitate catching any exception from this library.
+"""
+
+
 class CloudPathException(Exception):
     """Base exception for all cloudpathlib custom exceptions."""
 

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -46,7 +46,9 @@ class GSClient(Client):
         - Instantiated and already authenticated `Storage Client`.
 
         If multiple methods are used, priority order is reverse of list above
-        (later in list takes priority).
+        (later in list takes priority). If no authentication methods are used,
+        then the client will be instantiated as anonymous, which will only have
+        access to public buckets.
 
         Args:
             application_credentials (Optional[Union[str, os.PathLike]]): Path to Google service

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -19,7 +19,11 @@ except ModuleNotFoundError:
 
 @register_client_class("gs")
 class GSClient(Client):
-    """Client for Google Cloud Storage."""
+    """Client class for Google Cloud Storage which handles authentication with GCP for
+    [`GSPath`](../gspath/) instances. See documentation for the
+    [`__init__` method][cloudpathlib.gs.gsclient.GSClient.__init__] for detailed authentication
+    options.
+    """
 
     def __init__(
         self,

--- a/cloudpathlib/gs/gspath.py
+++ b/cloudpathlib/gs/gspath.py
@@ -12,6 +12,19 @@ if TYPE_CHECKING:
 
 @register_path_class("gs")
 class GSPath(CloudPath):
+    """Class for representing and operating on Google Cloud Storage URIs, in the style of the
+    Python standard library's [`pathlib` module](https://docs.python.org/3/library/pathlib.html).
+    Instances represent a path in GS with filesystem path semantics, and convenient methods allow
+    for basic operations like joining, reading, writing, iterating over contents, etc. This class
+    almost entirely mimics the [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
+    interface, so most familiar properties and methods should be available and behave in the
+    expected way.
+
+    The [`GSClient`](../gsclient/) class handles authentication with GCP. If a client instance is
+    not explicitly specified on `GSPath` instantiation, a default client is used. See `GSClient`'s
+    documentation for more details.
+    """
+
     cloud_prefix: str = "gs://"
     client: "GSClient"
 

--- a/cloudpathlib/local/__init__.py
+++ b/cloudpathlib/local/__init__.py
@@ -1,3 +1,10 @@
+"""This module implements "Local" classes that mimic their associated `cloudpathlib` non-local
+counterparts but use the local filesystem in place of cloud storage. They can be used as drop-in
+replacements, with the intent that you can use them as mock or monkepatch substitutes in your
+tests. See ["Testing code that uses cloudpathlib"
+](https://cloudpathlib.drivendata.org/testing_mocked_cloudpathlib/) for usage examples.
+"""
+
 from .implementations import (
     local_azure_blob_implementation,
     LocalAzureBlobClient,

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -15,7 +15,9 @@ except ModuleNotFoundError:
 
 @register_client_class("s3")
 class S3Client(Client):
-    """Client for AWS S3."""
+    """Client class for AWS S3 which handles authentication with AWS for [`S3Path`](../s3path/)
+    instances. See documentation for the [`__init__` method][cloudpathlib.s3.s3client.S3Client.__init__]
+    for detailed authentication options."""
 
     def __init__(
         self,

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -35,6 +35,9 @@ class S3Client(Client):
         variables supported by boto3. See [boto3 Session documentation](
         https://boto3.amazonaws.com/v1/documentation/api/latest/guide/session.html).
 
+        If no authentication arguments or environment variables are provided, then the client will
+        be instantiated as anonymous, which will only have access to public buckets.
+
         Args:
             aws_access_key_id (Optional[str]): AWS access key ID.
             aws_secret_access_key (Optional[str]): AWS secret access key.

--- a/cloudpathlib/s3/s3path.py
+++ b/cloudpathlib/s3/s3path.py
@@ -12,6 +12,19 @@ if TYPE_CHECKING:
 
 @register_path_class("s3")
 class S3Path(CloudPath):
+    """Class for representing and operating on AWS S3 URIs, in the style of the Python standard
+    library's [`pathlib` module](https://docs.python.org/3/library/pathlib.html). Instances
+    represent a path in S3 with filesystem path semantics, and convenient methods allow for basic
+    operations like joining, reading, writing, iterating over contents, etc. This class almost
+    entirely mimics the [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
+    interface, so most familiar properties and methods should be available and behave in the
+    expected way.
+
+    The [`S3Client`](../s3client/) class handles authentication with AWS. If a client instance is
+    not explicitly specified on `S3Path` instantiation, a default client is used. See `S3Client`'s
+    documentation for more details.
+    """
+
     cloud_prefix: str = "s3://"
     client: "S3Client"
 

--- a/docs/docs/api-reference/anypath.md
+++ b/docs/docs/api-reference/anypath.md
@@ -1,3 +1,3 @@
-# AnyPath
+# cloudpathlib.AnyPath
 
 ::: cloudpathlib.anypath.AnyPath

--- a/docs/docs/api-reference/azblobclient.md
+++ b/docs/docs/api-reference/azblobclient.md
@@ -1,3 +1,3 @@
-# AzureBlobClient
+# cloudpathlib.AzureBlobClient
 
 ::: cloudpathlib.azure.azblobclient.AzureBlobClient

--- a/docs/docs/api-reference/azblobpath.md
+++ b/docs/docs/api-reference/azblobpath.md
@@ -1,3 +1,3 @@
-# AzureBlobPath
+# cloudpathlib.AzureBlobPath
 
 ::: cloudpathlib.azure.azblobpath.AzureBlobPath

--- a/docs/docs/api-reference/client.md
+++ b/docs/docs/api-reference/client.md
@@ -1,0 +1,3 @@
+# cloudpathlib.client
+
+::: cloudpathlib.client

--- a/docs/docs/api-reference/cloudpath.md
+++ b/docs/docs/api-reference/cloudpath.md
@@ -1,3 +1,3 @@
-# CloudPath
+# cloudpathlib.CloudPath
 
 ::: cloudpathlib.cloudpath.CloudPath

--- a/docs/docs/api-reference/exceptions.md
+++ b/docs/docs/api-reference/exceptions.md
@@ -1,0 +1,3 @@
+# cloudpathlib.exceptions
+
+::: cloudpathlib.exceptions

--- a/docs/docs/api-reference/gsclient.md
+++ b/docs/docs/api-reference/gsclient.md
@@ -1,3 +1,3 @@
-# GSClient
+# cloudpathlib.GSClient
 
 ::: cloudpathlib.gs.gsclient.GSClient

--- a/docs/docs/api-reference/gspath.md
+++ b/docs/docs/api-reference/gspath.md
@@ -1,3 +1,3 @@
-# GSPath
+# cloudpathlib.GSPath
 
 ::: cloudpathlib.gs.gspath.GSPath

--- a/docs/docs/api-reference/local.md
+++ b/docs/docs/api-reference/local.md
@@ -1,29 +1,52 @@
 # cloudpathlib.local
 
+## Attributes
+
 ::: cloudpathlib.local.local_azure_blob_implementation
     rendering:
         show_root_heading: true
-::: cloudpathlib.local.LocalAzureBlobClient
-    rendering:
-        show_root_heading: true
-::: cloudpathlib.local.LocalAzureBlobPath
-    rendering:
-        show_root_heading: true
+        heading_level: 3
 ::: cloudpathlib.local.local_gs_implementation
     rendering:
         show_root_heading: true
-::: cloudpathlib.local.LocalGSClient
-    rendering:
-        show_root_heading: true
-::: cloudpathlib.local.LocalGSPath
-    rendering:
-        show_root_heading: true
+        heading_level: 3
 ::: cloudpathlib.local.local_s3_implementation
     rendering:
         show_root_heading: true
+        heading_level: 3
+
+
+## Classes
+
+::: cloudpathlib.local.LocalAzureBlobClient
+    rendering:
+        show_root_heading: true
+        heading_level: 3
+::: cloudpathlib.local.LocalAzureBlobPath
+    rendering:
+        show_root_heading: true
+        heading_level: 3
+::: cloudpathlib.local.LocalClient
+    rendering:
+        show_root_heading: true
+        heading_level: 3
+::: cloudpathlib.local.LocalGSClient
+    rendering:
+        show_root_heading: true
+        heading_level: 3
+::: cloudpathlib.local.LocalGSPath
+    rendering:
+        show_root_heading: true
+        heading_level: 3
+::: cloudpathlib.local.LocalPath
+    rendering:
+        show_root_heading: true
+        heading_level: 3
 ::: cloudpathlib.local.LocalS3Client
     rendering:
         show_root_heading: true
+        heading_level: 3
 ::: cloudpathlib.local.LocalS3Path
     rendering:
         show_root_heading: true
+        heading_level: 3

--- a/docs/docs/api-reference/local.md
+++ b/docs/docs/api-reference/local.md
@@ -1,5 +1,9 @@
 # cloudpathlib.local
 
+::: cloudpathlib.local
+    selection:
+        members: false
+
 ## Attributes
 
 ::: cloudpathlib.local.local_azure_blob_implementation

--- a/docs/docs/api-reference/s3client.md
+++ b/docs/docs/api-reference/s3client.md
@@ -1,3 +1,3 @@
-# S3Client
+# cloudpathlib.S3Client
 
 ::: cloudpathlib.s3.s3client.S3Client

--- a/docs/docs/api-reference/s3path.md
+++ b/docs/docs/api-reference/s3path.md
@@ -1,3 +1,3 @@
-# S3Path
+# cloudpathlib.S3Path
 
 ::: cloudpathlib.s3.s3path.S3Path

--- a/docs/docs/stylesheets/custom_mkdocstrings.css
+++ b/docs/docs/stylesheets/custom_mkdocstrings.css
@@ -8,22 +8,22 @@ div.doc-contents:not(.first) {
     padding-left: 2ch;
 }
 
-/* Class name headings */
+/* Class name headings for module docs */
 h3.doc.doc-heading>code {
     font-weight: bold;
 }
 
-/* Class attribute and method headings */
+/* Class attribute and method headings for module docs */
 h5.doc.doc-heading {
     font-size: 1em;
     text-transform: none;
 }
 
 /* Bold function, method, and attribute names */
-.doc.doc-heading span {
+.doc.doc-heading>code span {
     font-weight: bold;
 }
 
-.doc.doc-heading span~span {
+.doc.doc-heading>code span~span {
     font-weight: normal;
 }

--- a/docs/docs/stylesheets/custom_mkdocstrings.css
+++ b/docs/docs/stylesheets/custom_mkdocstrings.css
@@ -1,0 +1,29 @@
+.doc.doc-heading {
+    padding-left: 1ch;
+    padding-bottom: 5px;
+    background-color: #F8F8F8;
+}
+
+div.doc-contents:not(.first) {
+    padding-left: 2ch;
+}
+
+/* Class name headings */
+h3.doc.doc-heading>code {
+    font-weight: bold;
+}
+
+/* Class attribute and method headings */
+h5.doc.doc-heading {
+    font-size: 1em;
+    text-transform: none;
+}
+
+/* Bold function, method, and attribute names */
+.doc.doc-heading span {
+    font-weight: bold;
+}
+
+.doc.doc-heading span~span {
+    font-weight: normal;
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,6 +6,9 @@ theme:
   name: material
   logo: logo-no-text.svg
   favicon: favicon.svg
+  features:
+    - navigation.sections
+    - navigation.expand
 
 extra_css:
   - stylesheets/extra.css

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: cloudpathlib
-site_url: https://cloudpathlib.drivendata.org
+site_url: https://cloudpathlib.drivendata.org/
 site_description: A library that implements pathlib.Path methods for URIs for different cloud providers.
 repo_url: https://github.com/drivendataorg/cloudpathlib
 theme:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,6 +9,7 @@ theme:
 
 extra_css:
   - stylesheets/extra.css
+  - stylesheets/custom_mkdocstrings.css
 
 nav:
   - Home: "index.md"
@@ -20,25 +21,27 @@ nav:
   - Integrations: "integrations.md"
   - API Reference:
       - CloudPath: "api-reference/cloudpath.md"
-      - S3:
-          - S3Client: "api-reference/s3client.md"
-          - S3Path: "api-reference/s3path.md"
+      - AnyPath: "api-reference/anypath.md"
       - Azure:
           - AzureBlobClient: "api-reference/azblobclient.md"
           - AzureBlobPath: "api-reference/azblobpath.md"
+      - S3:
+          - S3Client: "api-reference/s3client.md"
+          - S3Path: "api-reference/s3path.md"
       - GS:
           - GSClient: "api-reference/gsclient.md"
           - GSPath: "api-reference/gspath.md"
-      - AnyPath: "api-reference/anypath.md"
-      - Local: "api-reference/local.md"
+      - Other Modules:
+          - cloudpathlib.client: "api-reference/client.md"
+          - cloudpathlib.local: "api-reference/local.md"
+  - Changelog: "changelog.md"
 
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
   - toc:
       permalink: True
-  - codehilite:
-      use_pygments: true
+      toc_depth: 3
 
 plugins:
   - search
@@ -55,7 +58,10 @@ plugins:
             show_root_toc_entry: false
             show_root_full_path: false
             show_if_no_docstring: true
+            show_signature_annotations: true
             show_source: true
-            heading_level: 3
+            heading_level: 2
+            group_by_category: true
+            show_category_heading: true
       watch:
         - cloudpathlib

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,7 +35,7 @@ nav:
       - GS:
           - GSClient: "api-reference/gsclient.md"
           - GSPath: "api-reference/gspath.md"
-      - Other Modules:
+      - Submodules:
           - cloudpathlib.client: "api-reference/client.md"
           - cloudpathlib.exceptions: "api-reference/exceptions.md"
           - cloudpathlib.local: "api-reference/local.md"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - AnyPath: "anypath-polymorphism.md"
   - Testing code that uses cloudpathlib: "testing_mocked_cloudpathlib.ipynb"
   - Integrations: "integrations.md"
+  - Changelog: "changelog.md"
   - API Reference:
       - CloudPath: "api-reference/cloudpath.md"
       - AnyPath: "api-reference/anypath.md"
@@ -38,7 +39,6 @@ nav:
           - cloudpathlib.client: "api-reference/client.md"
           - cloudpathlib.exceptions: "api-reference/exceptions.md"
           - cloudpathlib.local: "api-reference/local.md"
-  - Changelog: "changelog.md"
 
 markdown_extensions:
   - pymdownx.highlight

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
           - GSPath: "api-reference/gspath.md"
       - Other Modules:
           - cloudpathlib.client: "api-reference/client.md"
+          - cloudpathlib.exceptions: "api-reference/exceptions.md"
           - cloudpathlib.local: "api-reference/local.md"
   - Changelog: "changelog.md"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ matplotlib
 mkdocs>=1.1
 mkdocs-jupyter
 mkdocs-material
-mkdocstrings
+mkdocstrings>=0.15
 mypy
 pandas
 pillow

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ jupyter
 matplotlib
 mkdocs>=1.1
 mkdocs-jupyter
-mkdocs-material
+mkdocs-material>=7
 mkdocstrings>=0.15
 mypy
 pandas


### PR DESCRIPTION
Website:

- Updates the styling of the API reference section. In particular, this adds: category headers, grey background behind code signature headers, bolding of names in signatures, and some indentation within sections. I tried these out for erdantic and found they increased readability quite a bit.
- Trying out new `mkdocs-materials` features for navbar. **API Reference** is now a bolded section, and the collapsible elements are autoexpanded.

Improvements:

- Revised the opening sentence of our readme. I found the "nearly all" to be an awkward phrasing. 
- Wrote new docstrings for public-facing classes and submodules 

Fixes:

- Adds an empty h1 header to README to remove the `<h1>Home</h1>` that is automatically added on the website homepage. 
- Fix the path of the logo image in README to point to a GitHub raw link so that it will render on PyPI. Fixes #119 
- Fix broken styling on 404 pages by adding a trailing slash to `site_url` that is apparently necessary
