### PR TITLE
[WIP] Raise exception when open with write mode in call stack

### DIFF
--- a/cloudpathlib/exceptions.py
+++ b/cloudpathlib/exceptions.py
@@ -12,6 +12,10 @@ class AnyPathTypeError(CloudPathException, TypeError):
     pass
 
 
+class BuiltInOpenWriteError(CloudPathException):
+    pass
+
+
 class ClientMismatchError(CloudPathException, ValueError):
     pass
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -5,7 +5,11 @@ from time import sleep
 
 import pytest
 
-from cloudpathlib.exceptions import CloudPathIsADirectoryError, DirectoryNotEmptyError
+from cloudpathlib.exceptions import (
+    BuiltInOpenWriteError,
+    CloudPathIsADirectoryError,
+    DirectoryNotEmptyError,
+)
 
 
 def test_file_discovery(rig):
@@ -113,3 +117,26 @@ def test_os_open(rig):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     with open(p, "r") as f:
         assert f.readable()
+
+    with pytest.raises(BuiltInOpenWriteError):
+        with open(p, "w") as f:
+            pass
+
+    with pytest.raises(BuiltInOpenWriteError):
+        with open(p, "wb") as f:
+            pass
+
+    with pytest.raises(BuiltInOpenWriteError):
+        with open(p, "a") as f:
+            pass
+
+    with pytest.raises(BuiltInOpenWriteError):
+        with open(p, "r+") as f:
+            pass
+
+    # with pytest.raises(BuiltInOpenWriteError):
+    #     with open(
+    #         p,
+    #         "w",
+    #     ) as f:
+    #         pass


### PR DESCRIPTION
A pass at trying to detect when `__fspath__` is called by `open` with a write mode. IMO it doesn't work all that well. It appears `open` is a weird function that doesn't have its own frame in the call stack. It jumps from `__fspath__`'s frame directly to the frame that calls `open`. I don't think there's a straightforward way to get object references from the frames (it's bytecode or source), so also hard to reliably detect if `open` is being called on the cloud path instance, or to pick up on what mode `open` is being called with. 