### PR TITLE
Cloud implementation of shutil.copy and shutil.copytree

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,12 @@
 # cloudpathlib Changelog
 
-## v0.4.1 (unreleased)
+## v0.4.1 (2021-05-29)
 
 - Added support for custom S3-compatible object stores. This functionality is available via the `endpoint_url` keyword argument when instantiating an `S3Client` instance. See [documentation](https://cloudpathlib.drivendata.org/authentication/#accessing-custom-s3-compatible-object-stores) for more details. ([#138](https://github.com/drivendataorg/cloudpathlib/pull/138) thanks to [@YevheniiSemendiak](https://github.com/YevheniiSemendiak))
+- Added `CloudPath.upload_from` which uploads the passed path to this CloudPath (issuse [#58](https://github.com/drivendataorg/cloudpathlib/issues/58))
+- Added support for common file transfer functions based on `shutil`. Issue [#108](https://github.com/drivendataorg/cloudpathlib/issues/108). PR [#142](https://github.com/drivendataorg/cloudpathlib/pull/142).
+  - `CloudPath.copy` copy a file from one location to another. Can be cloud -> local or cloud -> cloud. If `client` is not the same, the file transits through the local machine.
+  - `CloudPath.copytree` reucrsively copy a directory from one location to another. Can be cloud -> local or cloud -> cloud. Uses `CloudPath.copy` so if `client` is not the same, the file transits through the local machine.
 
 ## v0.4.0 (2021-03-13)
 

--- a/README.md
+++ b/README.md
@@ -179,11 +179,14 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 | `symlink_to`           | ❌                | ❌         | ❌         |
 | `with_stem`            | ❌                | ❌         | ❌         |
 | `cloud_prefix`         | ✅                | ✅         | ✅         |
+| `copy`                 | ✅                | ✅         | ✅         |
+| `copytree`             | ✅                | ✅         | ✅         |
 | `download_to`          | ✅                | ✅         | ✅         |
 | `etag`                 | ✅                | ✅         | ✅         |
 | `fspath`               | ✅                | ✅         | ✅         |
 | `is_valid_cloudpath`   | ✅                | ✅         | ✅         |
 | `rmtree`               | ✅                | ✅         | ✅         |
+| `upload_from`          | ✅                | ✅         | ✅         |
 | `blob`                 | ✅                | ❌         | ✅         |
 | `bucket`               | ❌                | ✅         | ✅         |
 | `container`            | ✅                | ❌         | ❌         |

--- a/cloudpathlib/anypath.py
+++ b/cloudpathlib/anypath.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Union
 
@@ -52,3 +53,14 @@ class AnyPath(metaclass=AnyPathMeta):
         https://pydantic-docs.helpmanual.io/usage/types/#custom-data-types"""
         # Note __new__ is static method and not a class method
         return cls.__new__(cls, value)
+
+
+def to_anypath(s: Union[str, os.PathLike]) -> Union[CloudPath, Path]:
+    """Convenience method to convert a str or os.PathLike to the
+    proper Path or CloudPath object using AnyPath.
+    """
+    # shortcut pathlike items that are already valid Path/CloudPath
+    if isinstance(s, (CloudPath, Path)):
+        return s
+
+    return AnyPath(s)  # type: ignore

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -98,7 +98,7 @@ class AzureBlobClient(Client):
 
     def _download_file(
         self, cloud_path: AzureBlobPath, local_path: Union[str, os.PathLike]
-    ) -> Union[str, os.PathLike]:
+    ) -> Path:
         blob = self.service_client.get_blob_client(
             container=cloud_path.container, blob=cloud_path.blob
         )

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -171,7 +171,9 @@ class AzureBlobClient(Client):
 
             yield self.CloudPath(f"az://{cloud_path.container}/{o.name}")
 
-    def _move_file(self, src: AzureBlobPath, dst: AzureBlobPath) -> AzureBlobPath:
+    def _move_file(
+        self, src: AzureBlobPath, dst: AzureBlobPath, remove_src: bool = True
+    ) -> AzureBlobPath:
         # just a touch, so "REPLACE" metadata
         if src == dst:
             blob_client = self.service_client.get_blob_client(
@@ -189,7 +191,8 @@ class AzureBlobClient(Client):
 
             target.start_copy_from_url(source.url)
 
-            self._remove(src)
+            if remove_src:
+                self._remove(src)
 
         return dst
 

--- a/cloudpathlib/client.py
+++ b/cloudpathlib/client.py
@@ -60,7 +60,7 @@ class Client(abc.ABC, Generic[BoundedCloudPath]):
     @abc.abstractmethod
     def _download_file(
         self, cloud_path: BoundedCloudPath, local_path: Union[str, os.PathLike]
-    ) -> Union[str, os.PathLike]:
+    ) -> Path:
         pass
 
     @abc.abstractmethod

--- a/cloudpathlib/client.py
+++ b/cloudpathlib/client.py
@@ -83,7 +83,9 @@ class Client(abc.ABC, Generic[BoundedCloudPath]):
         pass
 
     @abc.abstractmethod
-    def _move_file(self, src: BoundedCloudPath, dst: BoundedCloudPath) -> BoundedCloudPath:
+    def _move_file(
+        self, src: BoundedCloudPath, dst: BoundedCloudPath, remove_src: bool = True
+    ) -> BoundedCloudPath:
         pass
 
     @abc.abstractmethod

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -585,7 +585,7 @@ class CloudPath(metaclass=CloudPathMeta):
         return self._dispatch_to_local_cache_path("read_text")
 
     # ===========  public cloud methods, not in pathlib ===============
-    def download_to(self, destination: Union[str, os.PathLike]) -> os.PathLike:
+    def download_to(self, destination: Union[str, os.PathLike]) -> Union[str, os.PathLike]:
         destination = Path(destination)
         if self.is_file():
             if destination.is_dir():
@@ -635,7 +635,7 @@ class CloudPath(metaclass=CloudPathMeta):
         self,
         destination: Union[str, os.PathLike, "CloudPath"],
         force_overwrite_to_cloud: bool = False,
-    ) -> Union[os.PathLike, "CloudPath"]:
+    ) -> Union[str, os.PathLike, "CloudPath"]:
         """Copy self to destination folder of file, if self is a file."""
         if not self.exists() or not self.is_file():
             raise ValueError(

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import os
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING, Union
 
 from ..client import Client, register_client_class
@@ -91,11 +91,11 @@ class GSClient(Client):
                 "updated": blob.updated,
             }
 
-    def _download_file(
-        self, cloud_path: GSPath, local_path: Union[str, os.PathLike]
-    ) -> Union[str, os.PathLike]:
+    def _download_file(self, cloud_path: GSPath, local_path: Union[str, os.PathLike]) -> Path:
         bucket = self.client.bucket(cloud_path.bucket)
         blob = bucket.get_blob(cloud_path.blob)
+
+        local_path = Path(local_path)
 
         blob.download_to_filename(local_path)
         return local_path

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -158,7 +158,7 @@ class GSClient(Client):
 
             yield self.CloudPath(f"gs://{cloud_path.bucket}/{o.name}")
 
-    def _move_file(self, src: GSPath, dst: GSPath) -> GSPath:
+    def _move_file(self, src: GSPath, dst: GSPath, remove_src: bool = True) -> GSPath:
         # just a touch, so "REPLACE" metadata
         if src == dst:
             bucket = self.client.bucket(src.bucket)
@@ -177,7 +177,9 @@ class GSClient(Client):
 
             src_blob = src_bucket.get_blob(src.blob)
             src_bucket.copy_blob(src_blob, dst_bucket, dst.blob)
-            src_blob.delete()
+
+            if remove_src:
+                src_blob.delete()
 
         return dst
 

--- a/cloudpathlib/local/localclient.py
+++ b/cloudpathlib/local/localclient.py
@@ -52,9 +52,7 @@ class LocalClient(Client):
             f"{cloud_prefix}{PurePosixPath(local_path.relative_to(self._local_storage_dir))}"
         )
 
-    def _download_file(
-        self, cloud_path: "LocalPath", local_path: Union[str, os.PathLike]
-    ) -> Union[str, os.PathLike]:
+    def _download_file(self, cloud_path: "LocalPath", local_path: Union[str, os.PathLike]) -> Path:
         local_path = Path(local_path)
         local_path.parent.mkdir(exist_ok=True, parents=True)
         shutil.copyfile(self._cloud_path_to_local(cloud_path), local_path)

--- a/cloudpathlib/local/localclient.py
+++ b/cloudpathlib/local/localclient.py
@@ -83,9 +83,15 @@ class LocalClient(Client):
     def _md5(self, cloud_path: "LocalPath") -> str:
         return md5(self._cloud_path_to_local(cloud_path).read_bytes()).hexdigest()
 
-    def _move_file(self, src: "LocalPath", dst: "LocalPath") -> "LocalPath":
+    def _move_file(
+        self, src: "LocalPath", dst: "LocalPath", remove_src: bool = True
+    ) -> "LocalPath":
         self._cloud_path_to_local(dst).parent.mkdir(exist_ok=True, parents=True)
-        self._cloud_path_to_local(src).replace(self._cloud_path_to_local(dst))
+
+        if remove_src:
+            self._cloud_path_to_local(src).replace(self._cloud_path_to_local(dst))
+        else:
+            shutil.copy(self._cloud_path_to_local(src), self._cloud_path_to_local(dst))
         return dst
 
     def _remove(self, cloud_path: "LocalPath") -> None:

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -154,7 +154,7 @@ class S3Client(Client):
                 for result_key in result.get("Contents", []):
                     yield self.CloudPath(f"s3://{cloud_path.bucket}/{result_key.get('Key')}")
 
-    def _move_file(self, src: S3Path, dst: S3Path) -> S3Path:
+    def _move_file(self, src: S3Path, dst: S3Path, remove_src: bool = True) -> S3Path:
         # just a touch, so "REPLACE" metadata
         if src == dst:
             o = self.s3.Object(src.bucket, src.key)
@@ -168,7 +168,8 @@ class S3Client(Client):
             target = self.s3.Object(dst.bucket, dst.key)
             target.copy({"Bucket": src.bucket, "Key": src.key})
 
-            self._remove(src)
+            if remove_src:
+                self._remove(src)
         return dst
 
     def _remove(self, cloud_path: S3Path) -> None:

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -1,5 +1,5 @@
 import os
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, Optional, Union
 
 from ..client import Client, register_client_class
@@ -79,9 +79,8 @@ class S3Client(Client):
             "extra": data["Metadata"],
         }
 
-    def _download_file(
-        self, cloud_path: S3Path, local_path: Union[str, os.PathLike]
-    ) -> Union[str, os.PathLike]:
+    def _download_file(self, cloud_path: S3Path, local_path: Union[str, os.PathLike]) -> Path:
+        local_path = Path(local_path)
         obj = self.s3.Object(cloud_path.bucket, cloud_path.key)
 
         obj.download_file(str(local_path))

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -1,0 +1,189 @@
+from pathlib import Path
+
+import pytest
+
+from cloudpathlib.local import LocalGSPath, LocalS3Path, LocalS3Client
+from cloudpathlib.exceptions import (
+    OverwriteNewerCloudError,
+)
+
+
+@pytest.fixture
+def upload_assets_dir(tmpdir):
+    tmp_assets = tmpdir.mkdir("test_upload_from_dir")
+    p = Path(tmp_assets)
+    (p / "upload_1.txt").write_text("Hello from 1")
+    (p / "upload_2.txt").write_text("Hello from 2")
+
+    sub = p / "subdir"
+    sub.mkdir(parents=True)
+    (sub / "sub_upload_1.txt").write_text("Hello from sub 1")
+    (sub / "sub_upload_2.txt").write_text("Hello from sub 2")
+
+    yield p
+
+
+def assert_mirrored(cloud_path, local_path, check_no_extra=True):
+    # file exists and is file
+    if local_path.is_file():
+        assert cloud_path.exists()
+        assert cloud_path.is_file()
+    else:
+        # all local files exist on cloud
+        for lp in local_path.iterdir():
+            assert_mirrored(cloud_path / lp.name, lp)
+
+        # no extra files on cloud
+        if check_no_extra:
+            assert len(list(local_path.glob("**/*"))) == len(list(cloud_path.glob("**/*")))
+
+    return True
+
+
+def test_upload_from_file(rig, upload_assets_dir):
+    to_upload = upload_assets_dir / "upload_1.txt"
+
+    # to file, file does not exists
+    p = rig.create_cloud_path("upload_test.txt")
+    assert not p.exists()
+
+    p.upload_from(to_upload)
+    assert p.exists()
+    assert p.read_text() == "Hello from 1"
+
+    # to file, file exists
+    to_upload_2 = upload_assets_dir / "upload_2.txt"
+    to_upload_2.touch()  # make sure local is newer
+    p.upload_from(to_upload_2)
+    assert p.exists()
+    assert p.read_text() == "Hello from 2"
+
+    # to file, file exists and is newer
+    p.touch()
+    with pytest.raises(OverwriteNewerCloudError):
+        p.upload_from(upload_assets_dir / "upload_1.txt")
+
+    # to file, file exists and is newer; overwrite
+    p.touch()
+    p.upload_from(upload_assets_dir / "upload_1.txt", force_overwrite_to_cloud=True)
+    assert p.exists()
+    assert p.read_text() == "Hello from 1"
+
+    # to dir, dir exists
+    p = rig.create_cloud_path("dir_0")  # created by fixtures
+    assert p.exists()
+    p.upload_from(upload_assets_dir / "upload_1.txt")
+    assert (p / "upload_1.txt").exists()
+    assert (p / "upload_1.txt").read_text() == "Hello from 1"
+
+
+def test_upload_from_dir(rig, upload_assets_dir):
+    # to dir, dir does not exists
+    p = rig.create_cloud_path("upload_test_dir")
+    assert not p.exists()
+
+    p.upload_from(upload_assets_dir)
+    assert assert_mirrored(p, upload_assets_dir)
+
+    # to dir, dir exists
+    p2 = rig.create_cloud_path("dir_0")  # created by fixtures
+    assert p2.exists()
+
+    p2.upload_from(upload_assets_dir)
+    assert assert_mirrored(p2, upload_assets_dir, check_no_extra=False)
+
+    # a newer file exists on cloud
+    (p / "upload_1.txt").touch()
+    with pytest.raises(OverwriteNewerCloudError):
+        p.upload_from(upload_assets_dir)
+
+    # force overwrite
+    (p / "upload_1.txt").touch()
+    (p / "upload_2.txt").unlink()
+    p.upload_from(upload_assets_dir, force_overwrite_to_cloud=True)
+    assert assert_mirrored(p, upload_assets_dir)
+
+
+def test_copy(rig, upload_assets_dir, tmpdir):
+    to_upload = upload_assets_dir / "upload_1.txt"
+    p = rig.create_cloud_path("upload_test.txt")
+    assert not p.exists()
+    p.upload_from(to_upload)
+    assert p.exists()
+
+    # cloud to local dir
+    dst = Path(tmpdir.mkdir("test_copy_to_local"))
+    out_file = p.copy(dst)
+    assert out_file.exists()
+    assert out_file.read_text() == "Hello from 1"
+    out_file.unlink()
+
+    p.copy(str(out_file))
+    assert out_file.exists()
+    assert out_file.read_text() == "Hello from 1"
+
+    # cloud to local file
+    p.copy(dst / "file.txt")
+
+    # cloud to cloud -> make sure no local cache
+    p_new = p.copy(p.parent / "new_upload_1.txt")
+    assert p_new.exists()
+    assert not p_new._local.exists()  # cache should never have been downloaded
+    assert not p._local.exists()  # cache should never have been downloaded
+    assert p_new.read_text() == "Hello from 1"
+
+    # cloud to cloud overwrite
+    p_new.touch()
+    with pytest.raises(OverwriteNewerCloudError):
+        p_new = p.copy(p_new)
+
+    p_new = p.copy(p_new, force_overwrite_to_cloud=True)
+    assert p_new.exists()
+
+    # cloud to other cloud
+    p2 = rig.create_cloud_path("dir_0/file0_0.txt")
+    other = (
+        LocalS3Path("s3://fake-bucket/new_other.txt")
+        if not isinstance(p2.client, LocalS3Client)
+        else LocalGSPath("gs://fake-bucket/new_other.txt")
+    )
+    assert not other.exists()
+
+    assert not p2._local.exists()  # not in cache
+    p2.copy(other)  # forces download + reupload
+    assert p2._local.exists()  # not in cache
+    assert other.exists()
+    assert other.read_text() == p2.read_text()
+
+    other.unlink()
+
+
+def test_copytree(rig, tmpdir):
+    # cloud dir to local dir that exists
+    p = rig.create_cloud_path("dir_0")
+    local_out = Path(tmpdir.mkdir("copytree_from_cloud"))
+    p.copytree(local_out)
+    assert assert_mirrored(p, local_out)
+
+    # cloud dir to local dir that does not exist
+    local_out = local_out / "new_folder"
+    p.copytree(local_out)
+    assert assert_mirrored(p, local_out)
+
+    # cloud dir to cloud dir that does not exist
+    p2 = rig.create_cloud_path("new_dir")
+    p.copytree(p2)
+    assert assert_mirrored(p2, p)
+
+    # cloud dir to cloud dir that exists
+    p2 = rig.create_cloud_path("new_dir2")
+    (p2 / "existing_file.txt").write_text("asdf")  # ensures p2 exists
+    p.copytree(p2)
+    assert assert_mirrored(p2, p, check_no_extra=False)
+
+    (p / "new_file.txt").write_text("hello!")  # add file so we can assert mirror
+    with pytest.raises(OverwriteNewerCloudError):
+        p.copytree(p2)
+
+    p.copytree(p2, force_overwrite_to_cloud=True)
+    assert assert_mirrored(p2, p, check_no_extra=False)

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from time import sleep
 
 import pytest
 
@@ -53,6 +54,7 @@ def test_upload_from_file(rig, upload_assets_dir):
 
     # to file, file exists
     to_upload_2 = upload_assets_dir / "upload_2.txt"
+    sleep(0.25)
     to_upload_2.touch()  # make sure local is newer
     p.upload_from(to_upload_2)
     assert p.exists()
@@ -65,6 +67,7 @@ def test_upload_from_file(rig, upload_assets_dir):
 
     # to file, file exists and is newer; overwrite
     p.touch()
+    sleep(0.25)
     p.upload_from(upload_assets_dir / "upload_1.txt", force_overwrite_to_cloud=True)
     assert p.exists()
     assert p.read_text() == "Hello from 1"

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -54,7 +54,7 @@ def test_upload_from_file(rig, upload_assets_dir):
 
     # to file, file exists
     to_upload_2 = upload_assets_dir / "upload_2.txt"
-    sleep(0.25)
+    sleep(0.5)
     to_upload_2.touch()  # make sure local is newer
     p.upload_from(to_upload_2)
     assert p.exists()
@@ -67,7 +67,7 @@ def test_upload_from_file(rig, upload_assets_dir):
 
     # to file, file exists and is newer; overwrite
     p.touch()
-    sleep(0.25)
+    sleep(0.5)
     p.upload_from(upload_assets_dir / "upload_1.txt", force_overwrite_to_cloud=True)
     assert p.exists()
     assert p.read_text() == "Hello from 1"


### PR DESCRIPTION
Seems like @genziano was busy (thanks for the initial work!), so I moved over his WIP from #125 to this branch.

@benasaf feel free to pick it up from here.

--------

Moved over PR from #125:

* Draft of cloudpathlib.copy, that replicates shutil.copy

* Import only PathLike from os

* Reuse _local_to_cloud_copy for cached files

* try to use the intended cached _local version

* Update cloudshutil.py

* Implemented the CloudPath methods: upload_from, copy, copytree

* Add docstrings

* Fix indentation

* fix unnecessary imports

* Fix typing issues

* Allow CloudPath.copy to a directory as well

Closes #58 
Closes #108 