### PR TITLE
Support TransferConfig for s3 uploads and downloads

### DIFF
--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -9,6 +9,7 @@ from .s3path import S3Path
 try:
     from boto3.session import Session
     import botocore.session
+    from boto3.s3.transfer import TransferConfig
 except ModuleNotFoundError:
     implementation_registry["s3"].dependencies_loaded = False
 
@@ -69,7 +70,9 @@ class S3Client(Client):
             )
         self.s3 = self.sess.resource("s3", endpoint_url=endpoint_url)
         self.client = self.sess.client("s3", endpoint_url=endpoint_url)
-        self.boto3_transfer_config = boto3_transfer_config
+        if boto3_transfer_config is None:
+            boto3_transfer_config = dict()
+        self.boto3_transfer_config = TransferConfig(**boto3_transfer_config)
 
         super().__init__(local_cache_dir=local_cache_dir)
 

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -30,7 +30,7 @@ class S3Client(Client):
         boto3_session: Optional["Session"] = None,
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,
         endpoint_url: Optional[str] = None,
-        boto3_transfer_config: Optional[dict] = None,
+        boto3_transfer_config: Optional["TransferConfig"] = None,
     ):
         """Class constructor. Sets up a boto3 [`Session`](
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html).
@@ -54,8 +54,7 @@ class S3Client(Client):
                 for downloaded files. If None, will use a temporary directory.
             endpoint_url (Optional[str]): S3 server endpoint URL to use for the constructed boto3 S3 resource and client.
                 Parameterize it to access a customly deployed S3-compatible object store such as MinIO, Ceph or any other.
-            boto3_transfer_config (Optional[dict]): TransferConfig parameters for controlling multipart
-                and threads in uploads and downloads.
+            boto3_transfer_config (Optional[dict]): Instantiated TransferConfig for managing s3 transfers.
                 (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig)
         """
         if boto3_session is not None:
@@ -70,9 +69,7 @@ class S3Client(Client):
             )
         self.s3 = self.sess.resource("s3", endpoint_url=endpoint_url)
         self.client = self.sess.client("s3", endpoint_url=endpoint_url)
-        if boto3_transfer_config is None:
-            boto3_transfer_config = dict()
-        self.boto3_transfer_config = TransferConfig(**boto3_transfer_config)
+        self.boto3_transfer_config = boto3_transfer_config
 
         super().__init__(local_cache_dir=local_cache_dir)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ mkdocstrings>=0.15
 mypy
 pandas
 pillow
+psutil
 pydantic
 pytest
 pytest-cases

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -70,11 +70,11 @@ class MockBoto3Object:
         else:
             self.path.write_bytes((self.root / Path(CopySource["Key"])).read_bytes())
 
-    def download_file(self, to_path):
+    def download_file(self, to_path, Config=None):
         to_path = Path(to_path)
         to_path.write_bytes(self.path.read_bytes())
 
-    def upload_file(self, from_path):
+    def upload_file(self, from_path, Config=None):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_bytes(Path(from_path).read_bytes())
 

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -56,7 +56,7 @@ def test_upload_from_file(rig, upload_assets_dir):
 
     # to file, file exists
     to_upload_2 = upload_assets_dir / "upload_2.txt"
-    sleep(0.5)
+    sleep(1.5)
     to_upload_2.touch()  # make sure local is newer
     p.upload_from(to_upload_2)
     assert p.exists()
@@ -69,7 +69,7 @@ def test_upload_from_file(rig, upload_assets_dir):
 
     # to file, file exists and is newer; overwrite
     p.touch()
-    sleep(0.5)
+    sleep(1.5)
     p.upload_from(upload_assets_dir / "upload_1.txt", force_overwrite_to_cloud=True)
     assert p.exists()
     assert p.read_text() == "Hello from 1"

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -98,6 +98,7 @@ def test_upload_from_dir(rig, upload_assets_dir):
     assert assert_mirrored(p2, upload_assets_dir, check_no_extra=False)
 
     # a newer file exists on cloud
+    sleep(1)
     (p / "upload_1.txt").touch()
     with pytest.raises(OverwriteNewerCloudError):
         p.upload_from(upload_assets_dir)

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -30,11 +30,13 @@ def test_transfer_config(s3_rig, assets_dir, tmp_path):
     dl_dir = tmp_path
     assert not (dl_dir / p.name).exists()
     p.download_to(dl_dir)
-    assert client.s3.download_config == transfer_config
+    if "mock_s3" in client.sess.__module__:
+        assert client.s3.download_config == transfer_config
 
     # upload
     p2 = s3_rig.create_cloud_path("dir_0/file0_0_uploaded.txt")
     assert not p2.exists()
     p2.upload_from(dl_dir / p.name)
-    assert client.s3.upload_config == transfer_config
+    if "mock_s3" in client.sess.__module__:
+        assert client.s3.upload_config == transfer_config
     p2.unlink()

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -2,6 +2,7 @@ import pytest
 
 from cloudpathlib import S3Path
 from cloudpathlib.local import LocalS3Path
+from boto3.s3.transfer import TransferConfig
 
 
 @pytest.mark.parametrize("path_class", [S3Path, LocalS3Path])
@@ -13,3 +14,27 @@ def test_s3path_properties(path_class):
     p2 = path_class("s3://bucket/")
     assert p2.key == ""
     assert p2.bucket == "bucket"
+
+
+def test_transfer_config(s3_rig, assets_dir, tmp_path):
+
+    transfer_config = TransferConfig(multipart_threshold=50)
+    client = s3_rig.client_class(boto3_transfer_config=transfer_config)
+    assert client.boto3_transfer_config.multipart_threshold == 50
+    # check defaults are inherited as well
+    assert client.boto3_transfer_config.use_threads
+
+    # download
+    client.set_as_default_client()
+    p = s3_rig.create_cloud_path("dir_0/file0_0.txt")
+    dl_dir = tmp_path
+    assert not (dl_dir / p.name).exists()
+    p.download_to(dl_dir)
+    assert client.s3.download_config == transfer_config
+
+    # upload
+    p2 = s3_rig.create_cloud_path("dir_0/file0_0_uploaded.txt")
+    assert not p2.exists()
+    p2.upload_from(dl_dir / p.name)
+    assert client.s3.upload_config == transfer_config
+    p2.unlink()

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -93,6 +93,7 @@ def test_transfer_config_live(s3_rig, tmp_path):
     used by a child process that does a download.
     """
     if s3_rig.live_server:
+
         def _execute_on_subprocess_and_observe(use_threads):
             main_test_process = psutil.Process().pid
 


### PR DESCRIPTION
Adds the ability to specify [boto3.s3.transfer.TransferConfig](https://boto3.amazonaws.com/v1/documentation/api/latest/_modules/boto3/s3/transfer.html#TransferConfig) parameters, which is useful for controlling multipart and thread use in uploads and downloads.

Outstanding:
- [x] test coverage

Closes #147 