### PR TITLE
Add versioned docs to CI

### DIFF
--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt --use-feature=2020-resolver
+          pip install -r requirements-dev.txt
           pip install -e .
 
       - name: Build docs

--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -33,7 +33,7 @@ jobs:
           git fetch origin gh-pages --depth=1
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          mike deploy --push ~dev --title=dev
+          mike deploy --push ~latest --title=latest
 
   deploy:
     name: Deploy docs to Netlify

--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and publish docs on master
+    name: Build docs from master
     runs-on: "ubuntu-latest"
 
     steps:
@@ -27,10 +27,28 @@ jobs:
         run: |
           make docs
 
+      - name: Stage docs on gh-pages
+        working-directory: docs
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          mike deploy --push ~dev --title=dev
+
+  deploy:
+    name: Deploy docs to Netlify
+    needs: build
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
       - name: Deploy docs to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:
-          publish-dir: "./docs/site"
+          publish-dir: "./"
           production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,16 @@ jobs:
           git fetch origin gh-pages --depth=1
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          # Rename old stable version
+          mike list -j | jq
+          OLD_STABLE=$(mike list -j | jq -r '.[] | select(.aliases | index("stable")) | .title' | awk '{print $1;}')
+          echo $OLD_STABLE
+          mike retitle stable $OLD_STABLE
+          # Deploy new version as stable
           mike deploy --push --update-aliases --no-redirect \
             ${{ steps.version.outputs.major_minor_version }} \
             stable \
-            --title=${{ github.event.release.tag_name }}
+            --title="${{ github.event.release.tag_name }} (stable)"
 
   deploy-docs:
     name: Deploy docs to Netlify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,13 @@ jobs:
           pip install -e .
 
       - name: Check that versions match
+        id: version
         run: |
-          echo "${{ github.event.release.tag_name }}"
+          echo "Release tag: [${{ github.event.release.tag_name }}]"
           PACKAGE_VERSION=$(python -c "import cloudpathlib; print(cloudpathlib.__version__)")
-          echo $PACKAGE_VERSION
+          echo "Package version: [$PACKAGE_VERSION]"
           [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
+          echo "::set-output name=major_minor_version::v${PACKAGE_VERSION%.*}"
 
       - name: Build package
         run: |
@@ -38,21 +40,6 @@ jobs:
       - name: Build docs
         run: |
           make docs
-
-      - name: Deploy docs to Netlify
-        uses: nwtgck/actions-netlify@v1.1
-        with:
-          publish-dir: "./docs/site"
-          production-deploy: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: false
-          enable-commit-comment: false
-          overwrites-pull-request-comment: false
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
 
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.0
@@ -68,3 +55,39 @@ jobs:
           user: ${{ secrets.PYPI_PROD_USERNAME }}
           password: ${{ secrets.PYPI_PROD_PASSWORD }}
           skip_existing: false
+
+      - name: Stage docs on gh-pages
+        working-directory: docs
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          mike deploy --push --update-aliases --no-redirect \
+            ${{ steps.version.outputs.major_minor_version }} \
+            stable \
+            --title=${{ github.event.release.tag_name }}
+
+  deploy-docs:
+    name: Deploy docs to Netlify
+    needs: build
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Deploy docs to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./"
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt --use-feature=2020-resolver
+          pip install -r requirements-dev.txt
           pip install -e .
 
       - name: Check that versions match

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     # Run every Sunday
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
   code-quality:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1></h1>
 
-[![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://cloudpathlib.drivendata.org/)
+[![Docs Status](https://img.shields.io/badge/docs-stable-informational)](https://cloudpathlib.drivendata.org/)
 [![PyPI](https://img.shields.io/pypi/v/cloudpathlib.svg)](https://pypi.org/project/cloudpathlib/)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/cloudpathlib.svg)](https://anaconda.org/conda-forge/cloudpathlib)
 [![tests](https://github.com/drivendataorg/cloudpathlib/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/cloudpathlib/actions?query=workflow%3Atests+branch%3Amaster)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,3 +69,7 @@ plugins:
             show_category_heading: true
       watch:
         - cloudpathlib
+
+extra:
+  version:
+    provider: mike

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,9 +6,10 @@ ipytest
 ipython
 jupyter
 matplotlib
-mkdocs>=1.1
+mike
+mkdocs>=1.2.2
 mkdocs-jupyter
-mkdocs-material>=7
+mkdocs-material>=7.2.6
 mkdocstrings>=0.15
 mypy
 pandas


### PR DESCRIPTION
Updates CI to publish versioned docs using mike. 

- `docs-master` will publish to `latest` version on any merges to master
- `release` workflow will publish and overwrite any previous docs with same `<major>.<minor>` version. The new version will also be tagged with `(stable)` and is assigned the alias `stable`.

We use `latest` and `stable` to refer to master branch and current release, respectively, per Read the Docs naming convention. I've also updated the README badge to say "stable" instead of "latest". 

All docs are stored on the `gh-pages` branch, and the workflows will push that branch to Netlify. I've manually backfilled existing releases. This won't be pushed to Netlify until the PR is merged. In the meantime, you can see https://erdantic.drivendata.org/ as an example. 

PR previews continue to work as-is without integration with the other versions. 

Closes #158 

--

Also adds `workflow_dispatch` trigger to `tests` workflow which enables manually triggering workflow in GitHub UI
