### PR TITLE
Upload live test coverage to codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,12 @@ jobs:
           CUSTOM_S3_SECRET_KEY: ${{secrets.CUSTOM_S3_SECRET_KEY}}
           CUSTOM_S3_ENDPOINT: ${{secrets.CUSTOM_S3_ENDPOINT}}
 
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true
+
   notify:
     name: Notify failed build
     needs: [code-quality, tests, live-tests]


### PR DESCRIPTION
Right now only mocked tests are reflected in codecov. 