### PR TITLE
Update _s3_file_query to check if an object exists explicitly. 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,9 @@
 # cloudpathlib Changelog
 
-## v0.6.1 (unreleased)
+## v0.6.1 (2021-09-17)
 
 - Fixed absolute documentation URLs to point to the new versioned documentation pages.
+- Fixed bug where `no_sign_request` couldn't be used to download files since our code required list permissions to the bucket to do so, which is tracked in issue [#169](https://github.com/drivendataorg/cloudpathlib/issues/169). PR [#168](https://github.com/drivendataorg/cloudpathlib/pull/168).
 
 ## v0.6.0 (2021-09-07)
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.6.0",
+    version="0.6.1",
 )

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -5,6 +5,7 @@ import shutil
 from tempfile import TemporaryDirectory
 
 from boto3.session import Session
+from botocore.exceptions import ClientError
 
 from .utils import delete_empty_parents_up_to_root
 
@@ -65,6 +66,16 @@ class MockBoto3Object:
             raise NoSuchKey({}, {})
         else:
             return {"key": self.path}
+
+    def load(self):
+        if not self.path.exists() or self.path.is_dir():
+            raise ClientError({}, {})
+        else:
+            return {"key": str(self.path)}
+
+    @property
+    def key(self):
+        return str(self.path.relative_to(self.root))
 
     def copy_from(self, CopySource=None, Metadata=None, MetadataDirective=None):
         if CopySource["Key"] == str(self.path.relative_to(self.root)):

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -65,17 +65,17 @@ class MockBoto3Object:
         if not self.path.exists() or self.path.is_dir():
             raise NoSuchKey({}, {})
         else:
-            return {"key": self.path}
+            return {"key": str(PurePosixPath(self.path))}
 
     def load(self):
         if not self.path.exists() or self.path.is_dir():
             raise ClientError({}, {})
         else:
-            return {"key": str(self.path)}
+            return {"key": str(PurePosixPath(self.path))}
 
     @property
     def key(self):
-        return str(self.path.relative_to(self.root))
+        return str(PurePosixPath(self.path).relative_to(PurePosixPath(self.root)))
 
     def copy_from(self, CopySource=None, Metadata=None, MetadataDirective=None):
         if CopySource["Key"] == str(self.path.relative_to(self.root)):

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -56,37 +56,31 @@ def _download_with_threads(s3_rig, tmp_path, use_threads):
     """Job used by tests to ensure Transfer config changes are
     actually passed through to boto3 and respected.
     """
-    try:
-        sleep(1)  # give test monitoring process time to start watching
+    sleep(1)  # give test monitoring process time to start watching
 
-        transfer_config = TransferConfig(
-            max_concurrency=100,
-            use_threads=use_threads,
-            multipart_chunksize=1 * 1024,
-            multipart_threshold=10 * 1024,
-        )
-        client = s3_rig.client_class(boto3_transfer_config=transfer_config)
-        p = client.CloudPath(f"s3://{s3_rig.drive}/{s3_rig.test_dir}/dir_0/file0_to_download.txt")
+    transfer_config = TransferConfig(
+        max_concurrency=100,
+        use_threads=use_threads,
+        multipart_chunksize=1 * 1024,
+        multipart_threshold=10 * 1024,
+    )
+    client = s3_rig.client_class(boto3_transfer_config=transfer_config)
+    p = client.CloudPath(f"s3://{s3_rig.drive}/{s3_rig.test_dir}/dir_0/file0_to_download.txt")
 
-        assert not p.exists()
+    assert not p.exists()
 
-        # file should be about 60KB
-        text = "lalala" * 10_000
-        p.write_text(text)
+    # file should be about 60KB
+    text = "lalala" * 10_000
+    p.write_text(text)
 
-        assert p.exists()
+    assert p.exists()
 
-        # assert not (dl_dir / p.name).exists()
-        p.download_to(tmp_path)
+    # assert not (dl_dir / p.name).exists()
+    p.download_to(tmp_path)
 
-        p.unlink()
+    p.unlink()
 
-        assert not p.exists()
-
-    finally:
-        p = s3_rig.create_cloud_path("dir_0/file0_0.txt")
-        if p.exists():
-            p.unlink()
+    assert not p.exists()
 
 
 def test_transfer_config_live(s3_rig, tmp_path):

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -31,7 +31,7 @@ def test_transfer_config(s3_rig, tmp_path):
 
     # download
     client.set_as_default_client()
-    p = s3_rig.create_cloud_path(f"{s3_rig.test_dir}/dir_0/file0_0.txt")
+    p = s3_rig.create_cloud_path("dir_0/file0_0.txt")
     p.write_text("test file")
 
     dl_dir = tmp_path
@@ -43,7 +43,7 @@ def test_transfer_config(s3_rig, tmp_path):
         assert client.s3.download_config == transfer_config
 
     # upload
-    p2 = s3_rig.create_cloud_path(f"{s3_rig.test_dir}/dir_0/file0_0_uploaded.txt")
+    p2 = s3_rig.create_cloud_path("dir_0/file0_0_uploaded.txt")
     assert not p2.exists()
     p2.upload_from(dl_dir / p.name)
 
@@ -86,7 +86,7 @@ def _download_with_threads(s3_rig, tmp_path, use_threads):
         assert not p.exists()
 
     finally:
-        p = s3_rig.create_cloud_path(f"{s3_rig.test_dir}/dir_0/file0_0.txt")
+        p = s3_rig.create_cloud_path("dir_0/file0_0.txt")
         if p.exists():
             p.unlink()
 
@@ -141,7 +141,6 @@ def test_no_sign_request(s3_rig, tmp_path):
     """Tests that we can pass no_sign_request to the S3Client and we will
     be able to access public resources but not private ones.
     """
-    tmp_path = Path(tmp_path)
     if s3_rig.live_server:
         client = s3_rig.client_class(no_sign_request=True)
 

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -1,6 +1,5 @@
 from concurrent.futures import ProcessPoolExecutor
 from time import sleep
-from pathlib import Path
 
 import pytest
 
@@ -32,7 +31,6 @@ def test_transfer_config(s3_rig, tmp_path):
     # download
     client.set_as_default_client()
     p = s3_rig.create_cloud_path("dir_0/file0_0.txt")
-    p.write_text("test file")
 
     dl_dir = tmp_path
     assert not (dl_dir / p.name).exists()


### PR DESCRIPTION
In  our current setup, the `_is_file_or_dir` check relies on `_s3_file_query`, which requires list permissions. When we pass `no_sign_request`, we want to be able to download public files without credentials. However, we're not able to use this functionality because we do not have list permissions to the bucket.

This change introduces a first check to see if an object exists using `load` (which just calls `head_object` so should have very little overhead and does not require list permissions). If that does not work, we do our normal call to see if it is a dir.

Downside:
1 extra network call in the case of a directory.

Bonuses:
 - Update `no_sign_request` test to include scenario that failed before this fix.
 - We used `get` which downloads the file where we should have used `load`. Fixed this instance.
 - Some other tests were failing because our test bucket had not been cleaned up. I changed these tests to properly use the `rig.test_dir` folder so state on the bucket shouldn't exist. Also removed cleanup performed by `_download_with_threads` in the test since it should be handled by the rig now.

Closes #169 