### PR TITLE
Fix missing botocore error when S3 deps not installed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,13 @@
 # cloudpathlib Changelog
 
+## v0.6.2 (2021-09-20)
+
+- Fixed error when importing `cloudpathlib` for missing `botocore` dependency when not installed with S3 dependencies. ([PR #168](https://github.com/drivendataorg/cloudpathlib/pull/168))
+
 ## v0.6.1 (2021-09-17)
 
 - Fixed absolute documentation URLs to point to the new versioned documentation pages.
-- Fixed bug where `no_sign_request` couldn't be used to download files since our code required list permissions to the bucket to do so, which is tracked in issue [#169](https://github.com/drivendataorg/cloudpathlib/issues/169). PR [#168](https://github.com/drivendataorg/cloudpathlib/pull/168).
+- Fixed bug where `no_sign_request` couldn't be used to download files since our code required list permissions to the bucket to do so. ([Issue #169](https://github.com/drivendataorg/cloudpathlib/issues/169), [PR #168](https://github.com/drivendataorg/cloudpathlib/pull/168)).
 
 ## v0.6.0 (2021-09-07)
 

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, Optional, Union
 
-from botocore.exceptions import ClientError
 
 from ..client import Client, register_client_class
 from ..cloudpath import implementation_registry
@@ -12,6 +11,7 @@ try:
     from boto3.session import Session
     from boto3.s3.transfer import TransferConfig
     from botocore.config import Config
+    from botocore.exceptions import ClientError
     import botocore.session
 except ModuleNotFoundError:
     implementation_registry["s3"].dependencies_loaded = False

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.6.1",
+    version="0.6.2",
 )


### PR DESCRIPTION
Surfaced by our smoke tests for our conda-forge feedstock: https://github.com/conda-forge/cloudpathlib-feedstock/pull/17/checks?check_run_id=3637922994