### PR TITLE
Handle and test for s3 fake directories

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # cloudpathlib Changelog
 
+## Unreleased (2022-01-05)
+
+ - Fixed error when "directories" created on AWS S3 were reported as files. ([Issue #148](https://github.com/drivendataorg/cloudpathlib/issues/148), [PR #190](https://github.com/drivendataorg/cloudpathlib/pull/190))
+
+
 ## v0.6.4 (2021-12-29)
 
  - Fixed error where `BlobProperties` type hint causes import error if Azure dependencies not installed.

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -124,8 +124,18 @@ class S3Client(Client):
             return None
 
         # since S3 only returns files when filtering objects:
-        # if the first item key is equal to the path key, this is a file; else it is a dir
-        return "file" if s3_obj.key == cloud_path.key else "dir"
+        # if the first item key is equal to the path key, this is a file
+        if s3_obj.key == cloud_path.key:
+
+            # "fake" directories on S3 can be created in the console UI
+            # these are 0-size keys that end in `/`
+            #  Ref: https://github.com/boto/boto3/issues/377
+            if s3_obj.key.endswith("/") and s3_obj.content_length == 0:
+                return "dir"
+            else:
+                return "file"
+        else:
+            return "dir"
 
     def _exists(self, cloud_path: S3Path) -> bool:
         return self._s3_file_query(cloud_path) is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,8 +395,8 @@ rig = fixture_union(
 )
 
 # run some s3-specific tests on custom s3 (ceph, minio, etc.) and aws s3
-live_s3_like_rig = fixture_union(
-    "live_s3_like_rig",
+s3_like_rig = fixture_union(
+    "s3_like_rig",
     [
         s3_rig,
         custom_s3_rig,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,3 +393,12 @@ rig = fixture_union(
         local_gs_rig,
     ],
 )
+
+# run some s3-specific tests on custom s3 (ceph, minio, etc.) and aws s3
+live_s3_like_rig = fixture_union(
+    "live_s3_like_rig",
+    [
+        s3_rig,
+        custom_s3_rig,
+    ],
+)

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -53,6 +53,30 @@ def test_file_discovery(rig):
     assert not p5.exists()
 
 
+def test_is_dir_is_file(rig, tmp_path):
+    # test on directories
+    dir_slash = rig.create_cloud_path("dir_0/")
+    dir_no_slash = rig.create_cloud_path("dir_0")
+    dir_nested_slash = rig.create_cloud_path("dir_1/dir_1_0/")
+    dir_nested_no_slash = rig.create_cloud_path("dir_1/dir_1_0")
+
+    for test_case in [dir_slash, dir_no_slash, dir_nested_slash, dir_nested_no_slash]:
+        assert test_case.is_dir()
+        assert not test_case.is_file()
+
+    file = rig.create_cloud_path("dir_0/file0_0.txt")
+    file_nested = rig.create_cloud_path("dir_1/dir_1_0/file_1_0_0.txt")
+
+    for test_case in [file, file_nested]:
+        assert test_case.is_file()
+        assert not test_case.is_dir()
+
+    # does not exist (same behavior as pathlib.Path that does not exist)
+    non_existant = rig.create_cloud_path("dir_0/not_a_file")
+    assert not non_existant.is_file()
+    assert not non_existant.is_dir()
+
+
 def test_file_read_writes(rig, tmp_path):
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     p2 = rig.create_cloud_path("dir_0/not_a_file")

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -89,47 +89,48 @@ def test_transfer_config_live(s3_rig, tmp_path):
     if the `use_threads` parameter changes to number of threads
     used by a child process that does a download.
     """
-    if s3_rig.live_server:
+    if not s3_rig.live_server:
+        pytest.skip("This test only runs against live servers.")
 
-        def _execute_on_subprocess_and_observe(use_threads):
-            main_test_process = psutil.Process().pid
+    def _execute_on_subprocess_and_observe(use_threads):
+        main_test_process = psutil.Process().pid
 
-            with ProcessPoolExecutor(max_workers=1) as executor:
-                job = executor.submit(
-                    _download_with_threads,
-                    s3_rig=s3_rig,
-                    tmp_path=tmp_path,
-                    use_threads=use_threads,
-                )
+        with ProcessPoolExecutor(max_workers=1) as executor:
+            job = executor.submit(
+                _download_with_threads,
+                s3_rig=s3_rig,
+                tmp_path=tmp_path,
+                use_threads=use_threads,
+            )
 
-                max_threads = 0
+            max_threads = 0
 
-                # timeout after 100 seconds
-                for _ in range(1000):
-                    worker_process_id = (
-                        psutil.Process(main_test_process).children()[-1].pid
-                    )  # most recently started child
-                    n_thread = psutil.Process(worker_process_id).num_threads()
+            # timeout after 100 seconds
+            for _ in range(1000):
+                worker_process_id = (
+                    psutil.Process(main_test_process).children()[-1].pid
+                )  # most recently started child
+                n_thread = psutil.Process(worker_process_id).num_threads()
 
-                    # observe number of threads used
-                    max_threads = max(max_threads, n_thread)
+                # observe number of threads used
+                max_threads = max(max_threads, n_thread)
 
-                    sleep(0.1)
+                sleep(0.1)
 
-                    if job.done():
-                        _ = job.result()  # raises if job raised
-                        break
+                if job.done():
+                    _ = job.result()  # raises if job raised
+                    break
 
-                return max_threads
+            return max_threads
 
-        # usually ~3 threads are spun up whe use_threads is False
-        assert _execute_on_subprocess_and_observe(use_threads=False) < 5
+    # usually ~3 threads are spun up whe use_threads is False
+    assert _execute_on_subprocess_and_observe(use_threads=False) < 5
 
-        # usually ~15 threads are spun up whe use_threads is True
-        assert _execute_on_subprocess_and_observe(use_threads=True) > 10
+    # usually ~15 threads are spun up whe use_threads is True
+    assert _execute_on_subprocess_and_observe(use_threads=True) > 10
 
 
-def test_fake_directories(live_s3_like_rig):
+def test_fake_directories(s3_like_rig):
     """S3 can have "fake" directories created
     either in the AWS S3 Console or by uploading
     a 0 size object ending in a `/`. If these objects
@@ -140,44 +141,48 @@ def test_fake_directories(live_s3_like_rig):
 
     Ref: https://github.com/boto/boto3/issues/377
     """
-    if live_s3_like_rig.live_server:
-        boto3_s3_client = live_s3_like_rig.client_class._default_client.client
+    if not s3_like_rig.live_server:
+        pytest.skip("This test only runs against live servers.")
 
-        response = boto3_s3_client.put_object(
-            Bucket=f"{live_s3_like_rig.drive}",
-            Body="",
-            Key=f"{live_s3_like_rig.test_dir}/fake_directory/",
-        )
+    boto3_s3_client = s3_like_rig.client_class._default_client.client
 
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    response = boto3_s3_client.put_object(
+        Bucket=f"{s3_like_rig.drive}",
+        Body="",
+        Key=f"{s3_like_rig.test_dir}/fake_directory/",
+    )
 
-        # test either way of referring to the directory (with and w/o terminal slash)
-        fake_dir_slash = live_s3_like_rig.create_cloud_path("fake_directory/")
-        fake_dir_no_slash = live_s3_like_rig.create_cloud_path("fake_directory")
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-        for test_case in [fake_dir_no_slash, fake_dir_slash]:
-            assert test_case.exists()
-            assert test_case.is_dir()
-            assert not test_case.is_file()
+    # test either way of referring to the directory (with and w/o terminal slash)
+    fake_dir_slash = s3_like_rig.create_cloud_path("fake_directory/")
+    fake_dir_no_slash = s3_like_rig.create_cloud_path("fake_directory")
+
+    for test_case in [fake_dir_no_slash, fake_dir_slash]:
+        assert test_case.exists()
+        assert test_case.is_dir()
+        assert not test_case.is_file()
 
 
 def test_no_sign_request(s3_rig, tmp_path):
     """Tests that we can pass no_sign_request to the S3Client and we will
     be able to access public resources but not private ones.
     """
-    if s3_rig.live_server:
-        client = s3_rig.client_class(no_sign_request=True)
+    if not s3_rig.live_server:
+        pytest.skip("This test only runs against live servers.")
 
-        # unsigned can access public path (part of AWS open data)
-        p = client.CloudPath(
-            "s3://ladi/Images/FEMA_CAP/2020/70349/DSC_0001_5a63d42e-27c6-448a-84f1-bfc632125b8e.jpg"
-        )
-        assert p.exists()
+    client = s3_rig.client_class(no_sign_request=True)
 
-        p.download_to(tmp_path)
-        assert (tmp_path / p.name).read_bytes() == p.read_bytes()
+    # unsigned can access public path (part of AWS open data)
+    p = client.CloudPath(
+        "s3://ladi/Images/FEMA_CAP/2020/70349/DSC_0001_5a63d42e-27c6-448a-84f1-bfc632125b8e.jpg"
+    )
+    assert p.exists()
 
-        # unsigned raises for private S3 file that exists
-        p = client.CloudPath(f"s3://{s3_rig.drive}/dir_0/file0_to_download.txt")
-        with pytest.raises(botocore.exceptions.ClientError):
-            p.exists()
+    p.download_to(tmp_path)
+    assert (tmp_path / p.name).read_bytes() == p.read_bytes()
+
+    # unsigned raises for private S3 file that exists
+    p = client.CloudPath(f"s3://{s3_rig.drive}/dir_0/file0_to_download.txt")
+    with pytest.raises(botocore.exceptions.ClientError):
+        p.exists()


### PR DESCRIPTION
#148 reported inconsistent `is_dir` behavior between having a trailing `/` on S3 and not having that `/`.

The root cause of this is that AWS does create "fake" folders. According to [this boto3 thread](https://github.com/boto/boto3/issues/377) these are just zero-size keys ending with `/`. This fix changes our file/dir check on s3 to count these zero-size keys as directories rather than files.

Note: since we use `load` to check for existence, this change does not incur any additional network calls.

Testing:
 - Added explicit `is_dir`/`is_file` test (note: I discovered that these pass without the change since we do not create these fake folders normally, but may be useful so I left them in)
 - Added explicit test when using "live" s3 backends. This test fails without the change and succeeds with it.  
 - Manually tested "folder" created with cyberduck
 - Manually tested "folder" created using AWS Console UI

Closes #148 