### PR TITLE
GS: Try default credentials before anonymous client

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## Unreleased (2022-01-05)
 
  - Fixed error when "directories" created on AWS S3 were reported as files. ([Issue #148](https://github.com/drivendataorg/cloudpathlib/issues/148), [PR #190](https://github.com/drivendataorg/cloudpathlib/pull/190))
-
+ - Fixed bug where GCE machines can instantiate default client, but we don't attempt it. ([Issue #191](https://github.com/drivendataorg/cloudpathlib/issues/191)
 
 ## v0.6.4 (2021-12-29)
 

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -11,7 +11,9 @@ try:
     if TYPE_CHECKING:
         from google.auth.credentials import Credentials
 
+    from google.auth.exceptions import DefaultCredentialsError
     from google.cloud.storage import Client as StorageClient
+
 
 except ModuleNotFoundError:
     implementation_registry["gs"].dependencies_loaded = False
@@ -74,7 +76,10 @@ class GSClient(Client):
         elif application_credentials is not None:
             self.client = StorageClient.from_service_account_json(application_credentials)
         else:
-            self.client = StorageClient.create_anonymous_client()
+            try:
+                self.client = StorageClient()
+            except DefaultCredentialsError:
+                self.client = StorageClient.create_anonymous_client()
 
         super().__init__(local_cache_dir=local_cache_dir)
 


### PR DESCRIPTION
As reported in #191 in Google Cloud Engine, default credentials allow access. Anonymous clients are now used as a fallback after trying default credentials.

Closes #191 