### PR TITLE
Add ability to set endpoint_url from AWS_ENDPOINT_URL

### DIFF
--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -64,6 +64,7 @@ class S3Client(Client):
             boto3_transfer_config (Optional[dict]): Instantiated TransferConfig for managing s3 transfers.
                 (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig)
         """
+        endpoint_url = endpoint_url or os.getenv("AWS_ENDPOINT_URL")
         if boto3_session is not None:
             self.sess = boto3_session
         else:

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -5,7 +5,7 @@ import pytest
 
 from boto3.s3.transfer import TransferConfig
 import botocore
-from cloudpathlib import S3Path
+from cloudpathlib import S3Client, S3Path
 from cloudpathlib.local import LocalS3Path
 import psutil
 
@@ -186,3 +186,19 @@ def test_no_sign_request(s3_rig, tmp_path):
     p = client.CloudPath(f"s3://{s3_rig.drive}/dir_0/file0_to_download.txt")
     with pytest.raises(botocore.exceptions.ClientError):
         p.exists()
+
+
+def test_aws_endpoint_url_env(monkeypatch):
+    """Allows setting endpoint_url from env variable
+    until upstream boto3 PR is merged.
+    https://github.com/boto/boto3/pull/2746
+    """
+    s3_url = "https://s3.amazonaws.com"
+    localstack_url = "http://localhost:4566"
+
+    s3_client = S3Client()
+    assert s3_client.client.meta.endpoint_url == s3_url
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", localstack_url)
+    s3_client_custom_endpoint = S3Client()
+    assert s3_client_custom_endpoint.client.meta.endpoint_url == localstack_url


### PR DESCRIPTION
Merge changes from #193 into `master`.

(Using local branch so live endpoint tests also execute.)