### PR TITLE
fix: download_to function tried to download path files

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -587,22 +587,21 @@ class CloudPath(metaclass=CloudPathMeta):
         return self._dispatch_to_local_cache_path("read_text")
 
     # ===========  public cloud methods, not in pathlib ===============
-    def download_to(self, destination: Union[str, os.PathLike]) -> Path:
+    def download_to(self, destination: Union[str, os.PathLike], parents=False) -> Path:
         destination = Path(destination)
         if self.is_file():
             if destination.is_dir():
                 destination = destination / self.name
             return self.client._download_file(self, destination)
         else:
-            destination.mkdir(parents=True, exist_ok=True)
+            destination.mkdir(parents=parents, exist_ok=True)
             for f in self.iterdir():
                 rel = str(self)
                 if not rel.endswith("/"):
                     rel = rel + "/"
 
                 rel_dest = str(f)[len(rel) :]
-                if rel_dest != "":
-                    f.download_to(destination / rel_dest)
+                f.download_to(destination / rel_dest)
 
             return destination
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -594,14 +594,10 @@ class CloudPath(metaclass=CloudPathMeta):
                 destination = destination / self.name
             return self.client._download_file(self, destination)
         else:
-            destination.mkdir(exist_ok=True)
+            destination.mkdir(parents=True, exist_ok=True)
             for f in self.iterdir():
-                rel = str(self)
-                if not rel.endswith("/"):
-                    rel = rel + "/"
-
-                rel_dest = str(f)[len(rel) :]
-                f.download_to(destination / rel_dest)
+                if f.is_file():
+                    f.download_to(self.local_download_path)
 
             return destination
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -596,8 +596,13 @@ class CloudPath(metaclass=CloudPathMeta):
         else:
             destination.mkdir(parents=True, exist_ok=True)
             for f in self.iterdir():
-                if f.is_file():
-                    f.download_to(self.local_download_path)
+                rel = str(self)
+                if not rel.endswith("/"):
+                    rel = rel + "/"
+
+                rel_dest = str(f)[len(rel) :]
+                if rel_dest != "":
+                    f.download_to(destination / rel_dest)
 
             return destination
 


### PR DESCRIPTION
In download directory cases, the `download_to` function was running in an infinite loop. For example:

We have a s3 example bucket with 1 one file in it:
`s3://example/test_file.txt`

The function `iterdir()` will return:

```
s3://example/
s3://example/test_file.txt
````

In this case the `rel_dest` variable will be an empty string for the first case and `test_file.txt` for the second one.

The `f.download_to(destination / rel_dest)` will call the `download_to` function with `re_dest` as empty, causing an infinite loop.


The solution was to just verify if `re_dest` is not empty.

I also added the `parents=True` to `destination.mkdir` so it will create the directory even if is missing intermediate parent directories.





