### PR TITLE
Silence mypy error due to azure-storage-blob typing bug

### DIFF
--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -220,7 +220,7 @@ class AzureBlobClient(Client):
             container=cloud_path.container, blob=cloud_path.blob
         )
 
-        blob.upload_blob(Path(local_path).read_bytes(), overwrite=True)
+        blob.upload_blob(Path(local_path).read_bytes(), overwrite=True) # type: ignore
 
         return cloud_path
 

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -220,7 +220,7 @@ class AzureBlobClient(Client):
             container=cloud_path.container, blob=cloud_path.blob
         )
 
-        blob.upload_blob(Path(local_path).read_bytes(), overwrite=True) # type: ignore
+        blob.upload_blob(Path(local_path).read_bytes(), overwrite=True)  # type: ignore
 
         return cloud_path
 


### PR DESCRIPTION
This is a temporary workaround until the next release _after_ `azure-storage-blob` 12.10.0. See #214 