### PR TITLE
Azure type error fix

### DIFF
--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -109,7 +109,7 @@ class AzureBlobClient(Client):
 
         local_path.parent.mkdir(exist_ok=True, parents=True)
 
-        local_path.write_bytes(download_stream.readall())
+        local_path.write_bytes(download_stream.content_as_bytes())
 
         return local_path
 

--- a/tests/mock_clients/mock_azureblob.py
+++ b/tests/mock_clients/mock_azureblob.py
@@ -89,6 +89,9 @@ class MockStorageStreamDownloader:
     def readall(self):
         return (self.root / self.key).read_bytes()
 
+    def content_as_bytes(self):
+        return self.readall()
+
 
 class MockContainerClient:
     def __init__(self, root):


### PR DESCRIPTION
mypy fails with the error:

```
cloudpathlib/azure/azblobclient.py:112: error: Argument 1 to "write_bytes" of "Path" has incompatible type "Union[bytes, str]"; expected "bytes"
```

To fix this, we update azure's `_download_file` to use the explicit `content_as_bytes` instead of `readall`.

This is because `readall` can return bytes or a string, but write_bytes requires bytes. [See implementation here for reference](https://github.com/Azure/azure-sdk-for-python/blob/af456fe75579532bdc9d02f54755137a0f75d1d0/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py#L431-L458).


Fixes #225