### PR TITLE
Improve compatibility with pathlib by implementing more common methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,15 @@
 # cloudpathlib Changelog
 
+## v0.9.0 (UNRELEASED)
+ - Added `absolute` to `CloudPath` (does nothing as `CloudPath` is always absolute) ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Added `resolve` to `CloudPath` (does nothing as `CloudPath` is resolved in advance) ([Issue #151](https://github.com/drivendataorg/cloudpathlib/issues/151), [PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Added `relative_to` to `CloudPath` which returns a PosixPath ([Issue #149](https://github.com/drivendataorg/cloudpathlib/issues/149), [PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Added `is_relative_to` to `CloudPath` ([Issue #149](https://github.com/drivendataorg/cloudpathlib/issues/149), [PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Added `is_absolute` to `CloudPath` (always true as `CloudPath` is always absolute) ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Accept and delegate `read_text` parameters to cached file ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Add `exist_ok` parameter to `touch` ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Add `missing_ok` parameter to `unlink`, which defaults to True. This diverges from pathlib to maintain backward compatibility ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+
 ## v0.8.0 (2022-05-19)
 
  - Fixed pickling of `CloudPath` objects not working. ([Issue #223](https://github.com/drivendataorg/cloudpathlib/issues/223), [PR #224](https://github.com/drivendataorg/cloudpathlib/pull/224))

--- a/README.md
+++ b/README.md
@@ -119,13 +119,16 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 
 | Methods + properties   | `AzureBlobPath`   | `S3Path`   | `GSPath`   |
 |:-----------------------|:------------------|:-----------|:-----------|
+| `absolute`             | ✅                | ✅         | ✅         |
 | `anchor`               | ✅                | ✅         | ✅         |
 | `as_uri`               | ✅                | ✅         | ✅         |
 | `drive`                | ✅                | ✅         | ✅         |
 | `exists`               | ✅                | ✅         | ✅         |
 | `glob`                 | ✅                | ✅         | ✅         |
+| `is_absolute`          | ✅                | ✅         | ✅         |
 | `is_dir`               | ✅                | ✅         | ✅         |
 | `is_file`              | ✅                | ✅         | ✅         |
+| `is_relative_to`       | ✅                | ✅         | ✅         |
 | `iterdir`              | ✅                | ✅         | ✅         |
 | `joinpath`             | ✅                | ✅         | ✅         |
 | `match`                | ✅                | ✅         | ✅         |
@@ -137,8 +140,10 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 | `parts`                | ✅                | ✅         | ✅         |
 | `read_bytes`           | ✅                | ✅         | ✅         |
 | `read_text`            | ✅                | ✅         | ✅         |
+| `relative_to`          | ✅                | ✅         | ✅         |
 | `rename`               | ✅                | ✅         | ✅         |
 | `replace`              | ✅                | ✅         | ✅         |
+| `resolve`              | ✅                | ✅         | ✅         |
 | `rglob`                | ✅                | ✅         | ✅         |
 | `rmdir`                | ✅                | ✅         | ✅         |
 | `samefile`             | ✅                | ✅         | ✅         |
@@ -152,19 +157,16 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 | `with_suffix`          | ✅                | ✅         | ✅         |
 | `write_bytes`          | ✅                | ✅         | ✅         |
 | `write_text`           | ✅                | ✅         | ✅         |
-| `absolute`             | ❌                | ❌         | ❌         |
 | `as_posix`             | ❌                | ❌         | ❌         |
 | `chmod`                | ❌                | ❌         | ❌         |
 | `cwd`                  | ❌                | ❌         | ❌         |
 | `expanduser`           | ❌                | ❌         | ❌         |
 | `group`                | ❌                | ❌         | ❌         |
 | `home`                 | ❌                | ❌         | ❌         |
-| `is_absolute`          | ❌                | ❌         | ❌         |
 | `is_block_device`      | ❌                | ❌         | ❌         |
 | `is_char_device`       | ❌                | ❌         | ❌         |
 | `is_fifo`              | ❌                | ❌         | ❌         |
 | `is_mount`             | ❌                | ❌         | ❌         |
-| `is_relative_to`       | ❌                | ❌         | ❌         |
 | `is_reserved`          | ❌                | ❌         | ❌         |
 | `is_socket`            | ❌                | ❌         | ❌         |
 | `is_symlink`           | ❌                | ❌         | ❌         |
@@ -173,8 +175,6 @@ Most methods and properties from `pathlib.Path` are supported except for the one
 | `lstat`                | ❌                | ❌         | ❌         |
 | `owner`                | ❌                | ❌         | ❌         |
 | `readlink`             | ❌                | ❌         | ❌         |
-| `relative_to`          | ❌                | ❌         | ❌         |
-| `resolve`              | ❌                | ❌         | ❌         |
 | `root`                 | ❌                | ❌         | ❌         |
 | `symlink_to`           | ❌                | ❌         | ❌         |
 | `with_stem`            | ❌                | ❌         | ❌         |

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -205,19 +205,24 @@ class AzureBlobClient(Client):
 
         return dst
 
-    def _remove(self, cloud_path: AzureBlobPath) -> None:
-        if self._is_file_or_dir(cloud_path) == "dir":
+    def _remove(self, cloud_path: AzureBlobPath, missing_ok: bool = True) -> None:
+        file_or_dir = self._is_file_or_dir(cloud_path)
+        if file_or_dir == "dir":
             blobs = [
                 b.blob for b, is_dir in self._list_dir(cloud_path, recursive=True) if not is_dir
             ]
             container_client = self.service_client.get_container_client(cloud_path.container)
             container_client.delete_blobs(*blobs)
-        elif self._is_file_or_dir(cloud_path) == "file":
+        elif file_or_dir == "file":
             blob = self.service_client.get_blob_client(
                 container=cloud_path.container, blob=cloud_path.blob
             )
 
             blob.delete_blob()
+        else:
+            # Does not exist
+            if not missing_ok:
+                raise FileNotFoundError(f"File does not exist: {cloud_path}")
 
     def _upload_file(
         self, local_path: Union[str, os.PathLike], cloud_path: AzureBlobPath

--- a/cloudpathlib/azure/azblobpath.py
+++ b/cloudpathlib/azure/azblobpath.py
@@ -47,8 +47,10 @@ class AzureBlobPath(CloudPath):
         # not possible to make empty directory on blob storage
         pass
 
-    def touch(self):
+    def touch(self, exist_ok: bool = True):
         if self.exists():
+            if not exist_ok:
+                raise FileExistsError(f"File exists: {self}")
             self.client._move_file(self, self)
         else:
             tf = TemporaryDirectory()

--- a/cloudpathlib/client.py
+++ b/cloudpathlib/client.py
@@ -100,7 +100,7 @@ class Client(abc.ABC, Generic[BoundedCloudPath]):
         pass
 
     @abc.abstractmethod
-    def _remove(self, path: BoundedCloudPath) -> None:
+    def _remove(self, path: BoundedCloudPath, missing_ok: bool = True) -> None:
         """Remove a file or folder from the server.
 
         Parameters

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -196,17 +196,22 @@ class GSClient(Client):
 
         return dst
 
-    def _remove(self, cloud_path: GSPath) -> None:
-        if self._is_file_or_dir(cloud_path) == "dir":
+    def _remove(self, cloud_path: GSPath, missing_ok: bool = True) -> None:
+        file_or_dir = self._is_file_or_dir(cloud_path)
+        if file_or_dir == "dir":
             blobs = [
                 b.blob for b, is_dir in self._list_dir(cloud_path, recursive=True) if not is_dir
             ]
             bucket = self.client.bucket(cloud_path.bucket)
             for blob in blobs:
                 bucket.get_blob(blob).delete()
-        elif self._is_file_or_dir(cloud_path) == "file":
+        elif file_or_dir == "file":
             bucket = self.client.bucket(cloud_path.bucket)
             bucket.get_blob(cloud_path.blob).delete()
+        else:
+            # Does not exist
+            if not missing_ok:
+                raise FileNotFoundError(f"File does not exist: {cloud_path}")
 
     def _upload_file(self, local_path: Union[str, os.PathLike], cloud_path: GSPath) -> GSPath:
         bucket = self.client.bucket(cloud_path.bucket)

--- a/cloudpathlib/gs/gspath.py
+++ b/cloudpathlib/gs/gspath.py
@@ -42,8 +42,10 @@ class GSPath(CloudPath):
         # not possible to make empty directory on cloud storage
         pass
 
-    def touch(self):
+    def touch(self, exist_ok: bool = True):
         if self.exists():
+            if not exist_ok:
+                raise FileExistsError(f"File exists: {self}")
             self.client._move_file(self, self)
         else:
             tf = TemporaryDirectory()

--- a/cloudpathlib/local/localclient.py
+++ b/cloudpathlib/local/localclient.py
@@ -96,8 +96,11 @@ class LocalClient(Client):
             shutil.copy(self._cloud_path_to_local(src), self._cloud_path_to_local(dst))
         return dst
 
-    def _remove(self, cloud_path: "LocalPath") -> None:
+    def _remove(self, cloud_path: "LocalPath", missing_ok: bool = True) -> None:
         local_storage_path = self._cloud_path_to_local(cloud_path)
+        if not missing_ok and not local_storage_path.exists():
+            raise FileNotFoundError(f"File does not exist: {cloud_path}")
+
         if local_storage_path.is_file():
             local_storage_path.unlink()
         elif local_storage_path.is_dir():
@@ -121,8 +124,10 @@ class LocalClient(Client):
             )
         )
 
-    def _touch(self, cloud_path: "LocalPath") -> None:
+    def _touch(self, cloud_path: "LocalPath", exist_ok: bool = True) -> None:
         local_storage_path = self._cloud_path_to_local(cloud_path)
+        if local_storage_path.exists() and not exist_ok:
+            raise FileExistsError(f"File exists: {cloud_path}")
         local_storage_path.parent.mkdir(exist_ok=True, parents=True)
         local_storage_path.touch()
 

--- a/cloudpathlib/local/localpath.py
+++ b/cloudpathlib/local/localpath.py
@@ -28,5 +28,5 @@ class LocalPath(CloudPath):
             )
         return meta
 
-    def touch(self):
-        self.client._touch(self)
+    def touch(self, exist_ok: bool = True):
+        self.client._touch(self, exist_ok)

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -226,7 +226,7 @@ class S3Client(Client):
                 self._remove(src)
         return dst
 
-    def _remove(self, cloud_path: S3Path) -> None:
+    def _remove(self, cloud_path: S3Path, missing_ok: bool = True) -> None:
         try:
             obj = self.s3.Object(cloud_path.bucket, cloud_path.key)
 
@@ -250,6 +250,9 @@ class S3Client(Client):
             # resp will be [], so no need to check success
             if resp:
                 assert resp[0].get("ResponseMetadata").get("HTTPStatusCode") == 200
+            else:
+                if not missing_ok:
+                    raise FileNotFoundError(f"File does not exist: {cloud_path}")
 
     def _upload_file(self, local_path: Union[str, os.PathLike], cloud_path: S3Path) -> S3Path:
         obj = self.s3.Object(cloud_path.bucket, cloud_path.key)

--- a/cloudpathlib/s3/s3path.py
+++ b/cloudpathlib/s3/s3path.py
@@ -42,8 +42,10 @@ class S3Path(CloudPath):
         # not possible to make empty directory on s3
         pass
 
-    def touch(self):
+    def touch(self, exist_ok: bool = True):
         if self.exists():
+            if not exist_ok:
+                raise FileExistsError(f"File exists: {self}")
             self.client._move_file(self, self)
         else:
             tf = TemporaryDirectory()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ mike
 mkdocs>=1.2.2
 mkdocs-jupyter
 mkdocs-material>=7.2.6
-mkdocstrings>=0.15
+mkdocstrings[python]>=0.19.0
 mypy
 pandas
 pillow

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.8.0",
+    version="0.9.0",
 )

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -179,10 +179,15 @@ class MockCollection:
         return self.s3_obj_paths[:n]
 
     def delete(self):
+        any_deleted = False
         for p in self.full_paths:
+            if Path(p).exists():
+                any_deleted = True
             Path(p).unlink()
             delete_empty_parents_up_to_root(Path(p), self.root)
 
+        if not any_deleted:
+            return []
         return [{"ResponseMetadata": {"HTTPStatusCode": 200}}]
 
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -22,7 +22,13 @@ def test_file_discovery(rig):
     assert not p2.exists()
     p2.touch()
     assert p2.exists()
-    p2.unlink()
+    p2.touch(exist_ok=True)
+    with pytest.raises(FileExistsError):
+        p2.touch(exist_ok=False)
+    p2.unlink(missing_ok=False)
+    p2.unlink(missing_ok=True)
+    with pytest.raises(FileNotFoundError):
+        p2.unlink(missing_ok=False)
 
     p3 = rig.create_cloud_path("dir_0/")
     assert p3.exists()


### PR DESCRIPTION
Contributor PR of #230 to run the live tests.

---------------

* Added absolute, resolve and relative_to implementations

* Added tests interacting with PurePosixPaths

* Added is_absolute and is_relative_to as well

* Accept read_text parameters

* Added exist_ok paramter to touch

* Added missing_ok paramter to unlink

* Fixed formatting (make format)

* Update history.md & readme.md

* Fix relative_to on different providers (+ some naming changes

* Reformat

* Update history.md and bump version number to 0.9

* Update dev requirements for docs

* Fix readme list order

* Added test for relative_to on different provider cloud paths

* Remove unused import

* Updated relative_to different cloud test