### PR TITLE
Fix intersphinx inventory

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,8 +7,9 @@
  - Added `is_relative_to` to `CloudPath` ([Issue #149](https://github.com/drivendataorg/cloudpathlib/issues/149), [PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
  - Added `is_absolute` to `CloudPath` (always true as `CloudPath` is always absolute) ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
  - Accept and delegate `read_text` parameters to cached file ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
- - Add `exist_ok` parameter to `touch` ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
- - Add `missing_ok` parameter to `unlink`, which defaults to True. This diverges from pathlib to maintain backward compatibility ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Added `exist_ok` parameter to `touch` ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Added `missing_ok` parameter to `unlink`, which defaults to True. This diverges from pathlib to maintain backward compatibility ([PR #230](https://github.com/drivendataorg/cloudpathlib/pull/230))
+ - Fixed missing root object entries in documentation's Intersphinx inventory ([Issue #211](https://github.com/drivendataorg/cloudpathlib/issues/211), [PR #237](https://github.com/drivendataorg/cloudpathlib/pull/237))
 
 ## v0.8.0 (2022-05-19)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -55,12 +55,11 @@ plugins:
       default_handler: python
       handlers:
         python:
-          selection:
+          options:
             filters: ["!^_(?!_init__)"]
             inherited_members: true
-          rendering:
             show_root_heading: false
-            show_root_toc_entry: false
+            show_root_toc_entry: true
             show_root_full_path: false
             show_if_no_docstring: true
             show_signature_annotations: true
@@ -68,9 +67,10 @@ plugins:
             heading_level: 2
             group_by_category: true
             show_category_heading: true
-      watch:
-        - ../cloudpathlib
 
 extra:
   version:
     provider: mike
+
+watch:
+  - ../cloudpathlib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ mike
 mkdocs>=1.2.2
 mkdocs-jupyter
 mkdocs-material>=7.2.6
-mkdocstrings[python]>=0.19.0
+mkdocstrings[python-legacy]>=0.19.0
 mypy
 pandas
 pillow


### PR DESCRIPTION
Fixes missing entries from Intersphinx inventory file by including root object in TOC for mkdocstrings. Closes #211.

The inventory file is available at `<base-url>/objects.inv` and can be parsed by [sphobjinv](https://github.com/bskinn/sphobjinv).

Some additional changes:
- Migrates use of `watch` per mkdocstrings [deprecation note](https://mkdocstrings.github.io/usage/#watch-directories)
- Changes mkdocstrings handler from `python` to `python-legacy` to recover old behavior. There are a few issues like https://github.com/mkdocstrings/python/issues/9 that are not yet resolved in the new handler. 