### PR TITLE
Add py.typed for mypy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
 include requirements.txt
+include cloudpathlib/py.typed

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     include_package_data=True,
     name="cloudpathlib",
     packages=find_packages(exclude=["tests"]),
+    package_data={"cloudpathlib": ["py.typed"]},
     project_urls={
         "Bug Tracker": "https://github.com/drivendataorg/cloudpathlib/issues",
         "Documentation": "https://cloudpathlib.drivendata.org/",


### PR DESCRIPTION
Manually confirmed `mypy` fails on script with latest PyPI version, but succeeds with whl/source package built with this change.

Closes #243 