### PR TITLE
Make stat a method on CloudPath class

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -639,7 +639,6 @@ class CloudPath(metaclass=CloudPathMeta):
         else:
             return path_version
 
-    @property
     def stat(self):
         """Note: for many clients, we may want to override so we don't incur
         network costs since many of these properties are available as

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas
 pillow
 psutil
 pydantic
-pytest<7.0
+pytest
 pytest-cases
 pytest-cov
 python-dotenv


### PR DESCRIPTION
Make `stat` a method instead of a property to follow pathlib API.

Note: this is technically a potentially breaking change for anyone who implemented their own plugin `CloudPath` subclass, but didn't override `stat`. All of our classes override `stat` as a method properly.

Bonus fix for #203 since upstream breaking change was fixed we can unpin our `pytest` version

Fixes #234
Fixes #203 