### PR TITLE
Use abc.ABC as baseclass for AnyPath to fix issubclass behavior

### DIFF
--- a/cloudpathlib/anypath.py
+++ b/cloudpathlib/anypath.py
@@ -44,7 +44,7 @@ class AnyPath(ABC):
         return cls.__new__(cls, value)
 
 
-AnyPath.register(CloudPath)
+AnyPath.register(CloudPath)  # type: ignore
 AnyPath.register(Path)
 
 

--- a/cloudpathlib/anypath.py
+++ b/cloudpathlib/anypath.py
@@ -1,4 +1,5 @@
 import os
+from abc import ABC
 from pathlib import Path
 from typing import Union
 
@@ -6,19 +7,7 @@ from .cloudpath import InvalidPrefixError, CloudPath
 from .exceptions import AnyPathTypeError
 
 
-class AnyPathMeta(type):
-    """Metaclass for AnyPath that implements special methods so that AnyPath works as a virtual
-    superclass when using isinstance or issubclass checks on CloudPath or Path inputs. See
-    [PEP 3119](https://www.python.org/dev/peps/pep-3119/#overloading-isinstance-and-issubclass)."""
-
-    def __instancecheck__(cls, inst):
-        return isinstance(inst, CloudPath) or isinstance(inst, Path)
-
-    def __subclasscheck__(cls, sub):
-        return issubclass(sub, CloudPath) or issubclass(sub, Path)
-
-
-class AnyPath(metaclass=AnyPathMeta):
+class AnyPath(ABC):
     """Polymorphic virtual superclass for CloudPath and pathlib.Path. Constructing an instance will
     automatically dispatch to CloudPath or Path based on the input. It also supports both
     isinstance and issubclass checks.
@@ -53,6 +42,10 @@ class AnyPath(metaclass=AnyPathMeta):
         https://pydantic-docs.helpmanual.io/usage/types/#custom-data-types"""
         # Note __new__ is static method and not a class method
         return cls.__new__(cls, value)
+
+
+AnyPath.register(CloudPath)
+AnyPath.register(Path)
 
 
 def to_anypath(s: Union[str, os.PathLike]) -> Union[CloudPath, Path]:

--- a/tests/test_anypath.py
+++ b/tests/test_anypath.py
@@ -36,3 +36,7 @@ def test_anypath_cloudpath(rig):
 def test_anypath_bad_input():
     with pytest.raises(AnyPathTypeError):
         AnyPath(0)
+
+
+def test_anypath_subclass_anypath():
+    assert issubclass(AnyPath, AnyPath)


### PR DESCRIPTION
Following @jayqi's suggestion in https://github.com/drivendataorg/cloudpathlib/pull/247, this PR lets AnyPath inherit from abc.ABC and sets its subclasses via [ABC.register](https://docs.python.org/3/library/abc.html#abc.ABCMeta.register). It also adds a test to check the bug filed in https://github.com/drivendataorg/cloudpathlib/issues/246.

Fixes https://github.com/drivendataorg/cloudpathlib/issues/246