### PR TITLE
Use TypeVar for register_path_class decorator return type

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -12,7 +12,7 @@ from pathlib import (  # type: ignore
     _posix_flavour,
     _PathParents,
 )
-from typing import Any, IO, Iterable, Dict, Optional, TYPE_CHECKING, Union
+from typing import Any, IO, Iterable, Dict, Optional, Type, TYPE_CHECKING, TypeVar, Union
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -74,7 +74,9 @@ implementation_registry: defaultdict = defaultdict(CloudImplementation)
 
 
 def register_path_class(key: str):
-    def decorator(cls: type):
+    T = TypeVar("T", bound=Type[CloudPath])
+
+    def decorator(cls: Type[T]) -> Type[T]:
         if not issubclass(cls, CloudPath):
             raise TypeError("Only subclasses of CloudPath can be registered.")
         global implementation_registry


### PR DESCRIPTION
With the current implementation of `register_path_class`:

```python
def register_path_class(key: str):
    def decorator(cls: type):
        if not issubclass(cls, CloudPath):
            raise TypeError("Only subclasses of CloudPath can be registered.")
        global implementation_registry
        implementation_registry[key]._path_class = cls
        cls._cloud_meta = implementation_registry[key]
        return cls

    return decorator
```

the inferred type returned by `decorator` is `Type[CloudPath]` ... meaning we are losing class-specific type hint information when type hinting as subclasses of `CloudPath`:

<img width="309" alt="Screen Shot 2022-08-22 at 11 47 27 PM" src="https://user-images.githubusercontent.com/27844407/186073868-aafc1bfe-376a-4578-8fae-3089297863dd.png">


A simple fix for this is to explicitly return the same type that the decorator operates on using a `TypeVar`.
<img width="292" alt="Screen Shot 2022-08-22 at 11 47 50 PM" src="https://user-images.githubusercontent.com/27844407/186073907-2c9a8883-5e7c-4526-94ea-32260d071c3f.png">

