### PR TITLE
Add ignore keyword argument to copytree (#272)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # cloudpathlib Changelog
 
+## v0.11.0 (UNRELEASED)
+
+ - API change: Add `ignore` parameter to `CloudPath.copytree` in order to match `shutil` API. ([Issue #145](https://github.com/drivendataorg/cloudpathlib/issues/234), [PR #272](https://github.com/drivendataorg/cloudpathlib/pull/250))
+
+
 ## v0.10.0 (2022-08-18)
 
  - API change: Make `stat` on base class method instead of property to follow `pathlib` ([Issue #234](https://github.com/drivendataorg/cloudpathlib/issues/234), [PR #250](https://github.com/drivendataorg/cloudpathlib/pull/250))

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.10.0",
+    version="0.11.0-alpha",
 )


### PR DESCRIPTION
Local branch for live tests

* Add `ignore` keyword argument to `copytree`

The `ignore` argument expects a callable that returns a list of names that will be ignored while copying. It supports `shutil.ignore_patterns` [1] to allow using a similar interface.

Also, include proper typing according to the behaviour described in the Python docs on `shutil.copytree` and expanding it to support the `cloudpathlib` environment.

[1]: https://docs.python.org/3/library/shutil.html#shutil.ignore_patterns

Signed-off-by: Antonio Ossa Guerra <aaossa@uc.cl>

* Add tests for `ignore` argument on `copytree`

When the argument is not used (defaults to `None`), the function should work normally. The arguments is expected to be a callable that, given a list of names, returns a list of ignored names to skip those names while performing the copy.

The tests create additional files in the reference path (`p`): a Python file (`ignored.py`) and two directories (`dir1/` and `dir2/`). These files are ignored in two different ways, and tested separatelly: using `shutil.ignore_patterns` and using a custom ignore function

The tests are performed by copying the tree (and ignoring the files) and then comparing the source and destination (checking that every file in the destination is also in the source), and asserting that the ignored files do not exist in the destination.

Signed-off-by: Antonio Ossa Guerra <aaossa@uc.cl>

Signed-off-by: Antonio Ossa Guerra <aaossa@uc.cl>