### PR TITLE
Prevent file loss/exceptions when renaming

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -453,6 +453,15 @@ class CloudPath(metaclass=CloudPathMeta):
                 f"The target based to rename must be an instantiated class of type: {type(self)}"
             )
 
+        if self.is_dir():
+            raise CloudPathIsADirectoryError(
+                f"Path {self} is a directory; rename/replace the files recursively."
+            )
+
+        if target == self:
+            # Request is to replace/rename this with the same path - nothing to do
+            return self
+
         if target.exists():
             target.unlink()
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -38,6 +38,9 @@ def test_file_discovery(rig):
     with pytest.raises(CloudPathIsADirectoryError):
         p3.unlink()
 
+    with pytest.raises(CloudPathIsADirectoryError):
+        p3.rename(rig.create_cloud_path("dir_2/"))
+
     with pytest.raises(DirectoryNotEmptyError):
         p3.rmdir()
     p3.rmtree()
@@ -275,8 +278,13 @@ def test_file_read_writes(rig, tmp_path):
     assert not dest.exists()
     p.rename(dest)
     assert dest.exists()
-
     assert not p.exists()
+
+    dest_duplicate = rig.create_cloud_path("dir2/new_file0_0.txt")
+    assert dest == dest_duplicate
+    dest.rename(dest_duplicate)
+    assert dest.exists()
+
     p.touch()
     dest.replace(p)
     assert p.exists()


### PR DESCRIPTION
Fixes issue #277 

# Change Summary
1. Do nothing if renaming a file to have the same path as it currently has - previously the file was unlinked then an exception raised when trying to copy
2. Raise an explicit exception when attempting to rename a directory - the implementation only supports rename/replace of files, which raises an exception from within _move_file() if passed a directory

# Tests
I've added test conditions where it seemed appropriate within the existing test methods to exercise these changes - happy to move to separate test methods if preferred?