### PR TITLE
Prevent file loss/exceptions when renaming: (#278)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,8 @@
 
 ## v0.11.0 (UNRELEASED)
 
- - API change: Add `ignore` parameter to `CloudPath.copytree` in order to match `shutil` API. ([Issue #145](https://github.com/drivendataorg/cloudpathlib/issues/234), [PR #272](https://github.com/drivendataorg/cloudpathlib/pull/250))
+ - API change: Add `ignore` parameter to `CloudPath.copytree` in order to match `shutil` API. ([Issue #145](https://github.com/drivendataorg/cloudpathlib/issues/145), [PR #272](https://github.com/drivendataorg/cloudpathlib/pull/272))
+ - Prevent data loss when renaming by skipping files that would be renamed to the same thing. ([Issue #277](https://github.com/drivendataorg/cloudpathlib/issues/277), [PR #278](https://github.com/drivendataorg/cloudpathlib/pull/278))
 
 
 ## v0.10.0 (2022-08-18)

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -453,6 +453,15 @@ class CloudPath(metaclass=CloudPathMeta):
                 f"The target based to rename must be an instantiated class of type: {type(self)}"
             )
 
+        if self.is_dir():
+            raise CloudPathIsADirectoryError(
+                f"Path {self} is a directory; rename/replace the files recursively."
+            )
+
+        if target == self:
+            # Request is to replace/rename this with the same path - nothing to do
+            return self
+
         if target.exists():
             target.unlink()
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -38,6 +38,9 @@ def test_file_discovery(rig):
     with pytest.raises(CloudPathIsADirectoryError):
         p3.unlink()
 
+    with pytest.raises(CloudPathIsADirectoryError):
+        p3.rename(rig.create_cloud_path("dir_2/"))
+
     with pytest.raises(DirectoryNotEmptyError):
         p3.rmdir()
     p3.rmtree()
@@ -275,8 +278,13 @@ def test_file_read_writes(rig, tmp_path):
     assert not dest.exists()
     p.rename(dest)
     assert dest.exists()
-
     assert not p.exists()
+
+    dest_duplicate = rig.create_cloud_path("dir2/new_file0_0.txt")
+    assert dest == dest_duplicate
+    dest.rename(dest_duplicate)
+    assert dest.exists()
+
     p.touch()
     dest.replace(p)
     assert p.exists()


### PR DESCRIPTION
Local branch of #278 for running live tests

----------

Do nothing if renaming to the same path
Explicit exception when attempting to rename a dir