### PR TITLE
Add `dirs_exist_ok` to `CloudPath.copytree`

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -785,6 +785,7 @@ class CloudPath(metaclass=CloudPathMeta):
             ],
             collections.abc.Iterable,
         ] = None,
+        dirs_exist_ok: bool = False,
     ) -> Union[Path, "CloudPath"]:
         """Copy self to a directory, if self is a directory."""
         if not self.is_dir():
@@ -798,7 +799,11 @@ class CloudPath(metaclass=CloudPathMeta):
 
         if destination.exists() and destination.is_file():
             raise CloudPathFileExistsError(
-                "Destination path {destination} of copytree must be a directory."
+                f"Destination path {destination} of copytree must be a directory."
+            )
+        if destination.exists() and not dirs_exist_ok:
+            raise CloudPathFileExistsError(
+                f"Destination directory {destination} already exists and dirs_exist_ok is False."
             )
 
         contents = list(self.iterdir())

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -813,7 +813,7 @@ class CloudPath(metaclass=CloudPathMeta):
         else:
             ignored_names = set()
 
-        destination.mkdir(parents=True, exist_ok=True)
+        destination.mkdir(parents=True, exist_ok=dirs_exist_ok)
 
         for subpath in contents:
             if subpath.name in ignored_names:
@@ -826,6 +826,7 @@ class CloudPath(metaclass=CloudPathMeta):
                 subpath.copytree(
                     destination / subpath.name,
                     force_overwrite_to_cloud=force_overwrite_to_cloud,
+                    dirs_exist_ok=dirs_exist_ok,
                     ignore=ignore,
                 )
 

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -214,13 +214,17 @@ def test_copytree(rig, tmpdir):
     # cloud dir to local dir that exists
     p = rig.create_cloud_path("dir_1")
     local_out = Path(tmpdir.mkdir("copytree_from_cloud"))
-    p.copytree(local_out)
+    p.copytree(local_out, dirs_exist_ok=True)
     assert assert_mirrored(p, local_out)
 
     # str version of path
     local_out = Path(tmpdir.mkdir("copytree_to_str_path"))
-    p.copytree(str(local_out))
+    p.copytree(str(local_out), dirs_exist_ok=True)
     assert assert_mirrored(p, local_out)
+
+    # test dirs_exist_ok
+    with pytest.raises(CloudPathFileExistsError):
+        p.copytree(str(local_out), dirs_exist_ok=False)
 
     # cloud dir to local dir that does not exist
     local_out = local_out / "new_folder"
@@ -235,14 +239,18 @@ def test_copytree(rig, tmpdir):
     # cloud dir to cloud dir that exists
     p2 = rig.create_cloud_path("new_dir2")
     (p2 / "existing_file.txt").write_text("asdf")  # ensures p2 exists
-    p.copytree(p2)
+    p.copytree(p2, dirs_exist_ok=True)
     assert assert_mirrored(p2, p, check_no_extra=False)
+
+    # test dirs_exist_ok
+    with pytest.raises(CloudPathFileExistsError):
+        p.copytree(p2, dirs_exist_ok=False)
 
     (p / "new_file.txt").write_text("hello!")  # add file so we can assert mirror
     with pytest.raises(OverwriteNewerCloudError):
-        p.copytree(p2)
+        p.copytree(p2, dirs_exist_ok=True)
 
-    p.copytree(p2, force_overwrite_to_cloud=True)
+    p.copytree(p2, force_overwrite_to_cloud=True, dirs_exist_ok=True)
     assert assert_mirrored(p2, p, check_no_extra=False)
 
     # additional files that will be ignored using the ignore argument


### PR DESCRIPTION
closes #144

Adds `dirs_exist_ok` argument to `CloudPath.copytree`

The original issue suggests adding the `dirs_exist_ok` functionality through `mkdir`. Using `mkdir` on `S3Path` doesn't actually create a directory, since we can't make empty directories in cloud storage. Adding functionality to a no-op `mkdir` seemed misleading, so the new argument doesn't use `mkdir` to check if the destionation directory exists. Instead the functionality is added to `copytree` outside of `mkdir` with the more explicit `if destination.exists() and not dirs_exist_ok`.

### Questions

- Since `.mkdir` doesn't work on either `GSPath` or `S3Path`, should we raise an implementation error when it is called? Currently it runs without error, but doesn't actually create a directory.
  - For example, the `destination.mkdir` [line](https://github.com/drivendataorg/cloudpathlib/blob/fa8d9fd33cef12ed693d9e9cd69158b0f50b6d14/cloudpathlib/cloudpath.py#L811) in `CloudPath.copytree` doesn't actually create a cloud directory if it doesn't exist. The directory is created when the first file is copied with [`subpath.copy(...)`](https://github.com/drivendataorg/cloudpathlib/blob/fa8d9fd33cef12ed693d9e9cd69158b0f50b6d14/cloudpathlib/cloudpath.py#L817). Do we need to keep this line for cases when the destination directory is local?
  - If we raise an implementation error instead of pass without doing anything, the new [`S3Path.mkdir`](https://github.com/drivendataorg/cloudpathlib/blob/fa8d9fd33cef12ed693d9e9cd69158b0f50b6d14/cloudpathlib/s3/s3path.py#L41) definition would be:
  ```python
    def mkdir(self, parents=False, exist_ok=False):
        raise CloudPathNotImplementedError(
            "Empties directories cannot be created in cloud storage"
        )
  ```
  - We can add something similar, but with a general `NotImplementedError`, to [`GSPath.mkdir`](https://github.com/drivendataorg/cloudpathlib/blob/fa8d9fd33cef12ed693d9e9cd69158b0f50b6d14/cloudpathlib/gs/gspath.py#L41)

- There is a note in the comments that empty directories can't be created in other forms of cloud storage (`GSPath`) either. It seems like we can handle `GSPath` and `S3Path` similarly for adding `dirs_exist_ok`, is that right?
