### PR TITLE
Update install instructions to use quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To install a cloud service's SDK dependency when installing `cloudpathlib`, you 
 pip install cloudpathlib[s3,gs,azure]
 ```
 
+With some shells, you may need to use quotes:
+
+```bash
+pip install "cloudpathlib[s3,gs,azure]"
+```
+
 Currently supported cloud storage services are: `azure`, `gs`, `s3`. You can also use `all` to install all available services' dependencies.
 
 If you do not specify any extras or separately install any cloud SDKs, you will only be able to develop with the base classes for rolling your own cloud path class.


### PR DESCRIPTION
For some shells, like zsh, the `[` is a special character. If I follow the existing instructions I get an error:
```
>> pip install cloudpathlib[s3,gs,azure]
zsh: no matches found: cloudpathlib[s3,gs,azure]
```
This edit shows how to navigate this error by putting quotes around the package name and SDK dependencies.