### PR TITLE
CloudPath type hints (#298)

### DIFF
--- a/cloudpathlib/client.py
+++ b/cloudpathlib/client.py
@@ -61,7 +61,7 @@ class Client(abc.ABC, Generic[BoundedCloudPath]):
         self.__class__._default_client = self
 
     def CloudPath(self, cloud_path: Union[str, BoundedCloudPath]) -> BoundedCloudPath:
-        return self._cloud_meta.path_class(cloud_path=cloud_path, client=self)
+        return self._cloud_meta.path_class(cloud_path=cloud_path, client=self)  # type: ignore
 
     @abc.abstractmethod
     def _download_file(

--- a/cloudpathlib/local/implementations/azure.py
+++ b/cloudpathlib/local/implementations/azure.py
@@ -77,5 +77,6 @@ class LocalAzureBlobPath(LocalPath):
 
 LocalAzureBlobPath.__name__ = "AzureBlobPath"
 
+local_azure_blob_implementation.name = "azure"
 local_azure_blob_implementation._client_class = LocalAzureBlobClient
 local_azure_blob_implementation._path_class = LocalAzureBlobPath

--- a/cloudpathlib/local/implementations/gs.py
+++ b/cloudpathlib/local/implementations/gs.py
@@ -56,5 +56,6 @@ class LocalGSPath(LocalPath):
 
 LocalGSPath.__name__ = "GSPath"
 
+local_gs_implementation.name = "gs"
 local_gs_implementation._client_class = LocalGSClient
 local_gs_implementation._path_class = LocalGSPath

--- a/cloudpathlib/local/implementations/s3.py
+++ b/cloudpathlib/local/implementations/s3.py
@@ -56,5 +56,6 @@ class LocalS3Path(LocalPath):
 
 LocalS3Path.__name__ = "S3Path"
 
+local_s3_implementation.name = "s3"
 local_s3_implementation._client_class = LocalS3Client
 local_s3_implementation._path_class = LocalS3Path

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -e .[all]
 
 black
+coverage<7
 flake8
 ipytest
 ipython


### PR DESCRIPTION
* Improve cloudpath type hints

mainly provides improved type hints for derived classes of CloudPath thru the DerivedCloudPath TypeVar, e.g. now S3Path('s3://bucket/key') / '.txt' is also hinted as an S3Path; general improvements to static type hinting, e.g. mypy --strict now yields 124 errors down from 209; made attributes of CloudImplementation into class attributes also for improved hinting, necessitating a few couple line changes in the client and local path implementations

* Add name to local cloud path implementations

* Add mypy ignore directive related to CloudImplementation change

* Add overloads for copy and copytree

also add more specific self type to cloud_path __init__ parameter

Co-authored-by: Peter Bull <pjbull@gmail.com>