### PR TITLE
Speed up glob implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## v0.11.1 (UNRELEASED)
 
- - Speed up glob! ([Issue #274](https://github.com/drivendataorg/cloudpathlib/issues/274), [PR #303](https://github.com/drivendataorg/cloudpathlib/pull/303))
+ - Speed up glob! ([Issue #274](https://github.com/drivendataorg/cloudpathlib/issues/274), [PR #304](https://github.com/drivendataorg/cloudpathlib/pull/304))
 
 ## v0.11.0 (2022-12-18)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cloudpathlib Changelog
 
+## v0.11.1 (UNRELEASED)
+
+ - Speed up glob! ([Issue #274](https://github.com/drivendataorg/cloudpathlib/issues/274), [PR #303](https://github.com/drivendataorg/cloudpathlib/pull/303))
+
 ## v0.11.0 (2022-12-18)
 
  - API change: Add `ignore` parameter to `CloudPath.copytree` in order to match `shutil` API. ([Issue #145](https://github.com/drivendataorg/cloudpathlib/issues/145), [PR #272](https://github.com/drivendataorg/cloudpathlib/pull/272))

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -357,44 +357,67 @@ class CloudPath(metaclass=CloudPathMeta):
         if pattern.startswith(self.cloud_prefix) or pattern.startswith("/"):
             raise CloudPathNotImplementedError("Non-relative patterns are unsupported")
 
-    def _glob(self: DerivedCloudPath, selector) -> Generator[DerivedCloudPath, None, None]:
+    def _glob(
+        self: DerivedCloudPath, selector, recursive: bool
+    ) -> Generator[DerivedCloudPath, None, None]:
+        # build a tree structure for all files out of default dicts
+        Tree: Callable = lambda: defaultdict(Tree)
+
+        file_tree = Tree()
+
+        for f, is_dir in self.client._list_dir(self, recursive=recursive):
+            parts = str(f.relative_to(self)).split("/")
+
+            if len(parts) == 1:
+                # skip self
+                if parts[0] == ".":
+                    continue
+
+                file_tree[parts[0]] = Tree() if is_dir else None
+
+            else:
+                # put top-level folder in file tree
+                node = file_tree[parts[0]]
+
+                # add remaining folders
+                for part in parts[1:-1]:
+                    node = node[part]
+
+                # add last item pointing at empty Tree if it is a folder
+                # else pointing at nothing if it is a file
+                node[parts[-1]] = Tree() if is_dir else None
+
+        file_tree = dict(file_tree)  # freeze as normal dict before passing in
+
         root = _CloudPathSelectable(
-            PurePosixPath(self._no_prefix_no_drive),
-            {
-                PurePosixPath(c._no_prefix_no_drive): is_dir
-                for c, is_dir in self.client._list_dir(self, recursive=True)
-            },
-            is_dir=True,
-            exists=True,
+            self.name,
+            [p.name for p in self.parents[:-1]],  # all parents except bucket/container
+            file_tree,
         )
 
         for p in selector.select_from(root):
-            yield self.client.CloudPath(f"{self.cloud_prefix}{self.drive}{p}")
+            yield self.client.CloudPath(f"{self.cloud_prefix}{self.drive}/{p}")
 
     def glob(self: DerivedCloudPath, pattern: str) -> Generator[DerivedCloudPath, None, None]:
-        if pattern == "*":
-            yield from (path for path, is_file in self.client._list_dir(self, recursive=False))
-            return
-        if pattern == "**/*":
-            yield from (path for path, is_file in self.client._list_dir(self, recursive=True))
-            return
         self._glob_checks(pattern)
 
         pattern_parts = PurePosixPath(pattern).parts
         selector = _make_selector(tuple(pattern_parts), _posix_flavour)
 
-        yield from self._glob(selector)
+        yield from self._glob(
+            selector,
+            "/" in pattern
+            or "**"
+            in pattern,  # recursive listing needed if explicit ** or any sub folder in pattern
+        )
 
     def rglob(self: DerivedCloudPath, pattern: str) -> Generator[DerivedCloudPath, None, None]:
-        if pattern == "*":
-            yield from (path for path, is_file in self.client._list_dir(self, recursive=True))
-            return
         self._glob_checks(pattern)
 
         pattern_parts = PurePosixPath(pattern).parts
         selector = _make_selector(("**",) + tuple(pattern_parts), _posix_flavour)
 
-        yield from self._glob(selector)
+        yield from self._glob(selector, True)
 
     def iterdir(self: DerivedCloudPath) -> Generator[DerivedCloudPath, None, None]:
         for f, _ in self.client._list_dir(self, recursive=False):
@@ -1068,24 +1091,23 @@ class _CloudPathSelectableAccessor:
 class _CloudPathSelectable:
     def __init__(
         self,
-        relative_cloud_path: PurePosixPath,
-        children: Dict[PurePosixPath, bool],
-        is_dir: bool,
-        exists: bool,
+        name: str,
+        parents: List[str],
+        children: Any,  # Nested dictionaries as tree
+        exists: bool = True,
     ) -> None:
-        self._path = relative_cloud_path
+        self._name = name
         self._all_children = children
+        self._parents = parents
+        self._exists = exists
 
         self._accessor = _CloudPathSelectableAccessor(self.scandir)
 
-        self._is_dir = is_dir
-        self._exists = exists
-
     def __repr__(self) -> str:
-        return str(self._path)
+        return "/".join(self._parents + [self.name])
 
     def is_dir(self) -> bool:
-        return self._is_dir
+        return self._all_children is not None
 
     def exists(self) -> bool:
         return self._exists
@@ -1095,7 +1117,16 @@ class _CloudPathSelectable:
 
     @property
     def name(self) -> str:
-        return self._path.name
+        return self._name
+
+    def _make_child_relpath(self, part):
+        # pathlib internals shortcut; makes a relative path, even if it doesn't actually exist
+        return _CloudPathSelectable(
+            part,
+            self._parents + [self.name],
+            self._all_children.get(part, None),
+            exists=part in self._all_children,
+        )
 
     @staticmethod
     @contextmanager
@@ -1103,33 +1134,6 @@ class _CloudPathSelectable:
         root: "_CloudPathSelectable",
     ) -> Generator[Generator["_CloudPathSelectable", None, None], None, None]:
         yield (
-            root._make_child_relpath(c.name)
-            for c, _ in root._all_children.items()
-            if c.parent == root._path
-        )
-
-    def _filter_children(self, rel_to: PurePosixPath) -> Dict[PurePosixPath, bool]:
-        return {
-            c: is_dir
-            for c, is_dir in self._all_children.items()
-            if self._is_relative_to(c, rel_to)
-        }
-
-    @staticmethod
-    def _is_relative_to(maybe_child: PurePosixPath, maybe_parent: PurePosixPath):
-        try:
-            maybe_child.relative_to(maybe_parent)
-            return True
-        except ValueError:
-            return False
-
-    def _make_child_relpath(self, part: Union[str, os.PathLike]) -> "_CloudPathSelectable":
-        child = self._path / part
-        filtered_children = self._filter_children(child)
-
-        return _CloudPathSelectable(
-            child,
-            filtered_children,
-            is_dir=self._all_children.get(child, False),
-            exists=child in self._all_children,
+            _CloudPathSelectable(child, root._parents + [root._name], grand_children)
+            for child, grand_children in root._all_children.items()
         )

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.11.0",
+    version="0.11.1",
 )

--- a/tests/performance/perf_file_listing.py
+++ b/tests/performance/perf_file_listing.py
@@ -7,6 +7,6 @@ def folder_list(folder, recursive):
 
 def glob(folder, recursive):
     if recursive:
-        return {"n_items": len(list(folder.rglob("*")))}
+        return {"n_items": len(list(folder.rglob("*.item")))}
     else:
-        return {"n_items": len(list(folder.glob("*")))}
+        return {"n_items": len(list(folder.glob("*.item")))}

--- a/tests/performance/perf_file_listing.py
+++ b/tests/performance/perf_file_listing.py
@@ -3,3 +3,10 @@ def folder_list(folder, recursive):
     the number of items listed
     """
     return {"n_items": len(list(folder.client._list_dir(folder, recursive=recursive)))}
+
+
+def glob(folder, recursive):
+    if recursive:
+        return {"n_items": len(list(folder.rglob("*")))}
+    else:
+        return {"n_items": len(list(folder.glob("*")))}

--- a/tests/performance/runner.py
+++ b/tests/performance/runner.py
@@ -14,7 +14,7 @@ from loguru import logger
 from cloudpathlib import CloudPath
 
 
-from perf_file_listing import folder_list
+from perf_file_listing import folder_list, glob
 
 
 # make loguru and tqdm play nicely together
@@ -123,6 +123,18 @@ def main(root, iterations, burn_in):
                 PerfRunConfig(name="List normal non-recursive", args=[normal, False], kwargs={}),
                 PerfRunConfig(name="List deep recursive", args=[deep, True], kwargs={}),
                 PerfRunConfig(name="List deep non-recursive", args=[deep, False], kwargs={}),
+            ],
+        ),
+        (
+            "Glob scenarios",
+            glob,
+            [
+                PerfRunConfig(name="Glob shallow recursive", args=[shallow, True], kwargs={}),
+                PerfRunConfig(name="Glob shallow non-recursive", args=[shallow, False], kwargs={}),
+                PerfRunConfig(name="Glob normal recursive", args=[normal, True], kwargs={}),
+                PerfRunConfig(name="Glob normal non-recursive", args=[normal, False], kwargs={}),
+                PerfRunConfig(name="Glob deep recursive", args=[deep, True], kwargs={}),
+                PerfRunConfig(name="Glob deep non-recursive", args=[deep, False], kwargs={}),
             ],
         ),
     ]


### PR DESCRIPTION
I believe that globs were slow because the internals of how pathlib calls our functions made us loop over all of the files in the directory every time it was checking children, which happened for any nested file.

Instead of passing the whole file tree to every selectable instance and letting that object filter it down on demand, this implementation builds the entire file tree as nested dicts and then lets `scandir` walk those nested dicts. Each selectable now knows only about its direct parents/children.

Closes #274

# Perf results

The list and glob scenarios listed below are executed against the same file trees, so this lets us more or less compare raw `_list_dir` calls to the performance of glob. (Note: N: items is different because the glob test filters out folders).

## Before this change

Super slow........

```
                                  Performance suite results: (2022-12-20T01:29:29.267986)                                  
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Test Name      ┃ Config Name                ┃ Iterations ┃           Mean ┃              Std ┃            Max ┃ N Items ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ List Folders   │ List shallow recursive     │          2 │ 0:00:01.256078 │ ± 0:00:00.037748 │ 0:00:01.282770 │   5,500 │
│ List Folders   │ List shallow non-recursive │          2 │ 0:00:01.261018 │ ± 0:00:00.003631 │ 0:00:01.263586 │   5,500 │
│ List Folders   │ List normal recursive      │          2 │ 0:00:01.778471 │ ± 0:00:00.019042 │ 0:00:01.791936 │   7,877 │
│ List Folders   │ List normal non-recursive  │          2 │ 0:00:00.035925 │ ± 0:00:00.000327 │ 0:00:00.036156 │     113 │
│ List Folders   │ List deep recursive        │          2 │ 0:00:03.105114 │ ± 0:00:00.059515 │ 0:00:03.147197 │   7,955 │
│ List Folders   │ List deep non-recursive    │          2 │ 0:00:00.040619 │ ± 0:00:00.010220 │ 0:00:00.047846 │      31 │
│ Glob scenarios │ Glob shallow recursive     │          2 │ 0:06:58.346311 │ ± 0:00:00.956693 │ 0:06:59.022795 │   5,500 │
│ Glob scenarios │ Glob shallow non-recursive │          2 │ 0:04:39.675058 │ ± 0:00:00.115285 │ 0:04:39.756577 │   5,500 │
│ Glob scenarios │ Glob normal recursive      │          2 │ 0:00:54.873498 │ ± 0:00:00.014340 │ 0:00:54.883638 │   7,272 │
│ Glob scenarios │ Glob normal non-recursive  │          2 │ 0:00:06.609309 │ ± 0:00:00.005283 │ 0:00:06.613045 │      12 │
│ Glob scenarios │ Glob deep recursive        │          2 │ 0:04:09.120405 │ ± 0:00:01.541716 │ 0:04:10.210563 │   7,650 │
│ Glob scenarios │ Glob deep non-recursive    │          2 │ 0:00:05.651228 │ ± 0:00:00.232796 │ 0:00:05.815840 │      25 │
└────────────────┴────────────────────────────┴────────────┴────────────────┴──────────────────┴────────────────┴─────────┘
```

## After this change

Very little overhead when doing actual comparisons and filtering (~10%) beyond the vanilla `_list_dir` calls!

```
                                  Performance suite results: (2022-12-20T09:26:30.055262)                                  
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Test Name      ┃ Config Name                ┃ Iterations ┃           Mean ┃              Std ┃            Max ┃ N Items ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ List Folders   │ List shallow recursive     │         10 │ 0:00:01.213074 │ ± 0:00:00.047582 │ 0:00:01.307935 │   5,500 │
│ List Folders   │ List shallow non-recursive │         10 │ 0:00:01.235682 │ ± 0:00:00.020873 │ 0:00:01.276783 │   5,500 │
│ List Folders   │ List normal recursive      │         10 │ 0:00:01.764192 │ ± 0:00:00.059765 │ 0:00:01.825311 │   7,877 │
│ List Folders   │ List normal non-recursive  │         10 │ 0:00:00.036764 │ ± 0:00:00.004089 │ 0:00:00.047984 │     113 │
│ List Folders   │ List deep recursive        │         10 │ 0:00:03.052238 │ ± 0:00:00.457676 │ 0:00:04.332024 │   7,955 │
│ List Folders   │ List deep non-recursive    │         10 │ 0:00:00.032839 │ ± 0:00:00.002672 │ 0:00:00.038686 │      31 │
│ Glob scenarios │ Glob shallow recursive     │         10 │ 0:00:01.484482 │ ± 0:00:00.065573 │ 0:00:01.561880 │   5,500 │
│ Glob scenarios │ Glob shallow non-recursive │         10 │ 0:00:01.481584 │ ± 0:00:00.029798 │ 0:00:01.523332 │   5,500 │
│ Glob scenarios │ Glob normal recursive      │         10 │ 0:00:02.017116 │ ± 0:00:00.055220 │ 0:00:02.115873 │   7,272 │
│ Glob scenarios │ Glob normal non-recursive  │         10 │ 0:00:00.037116 │ ± 0:00:00.003030 │ 0:00:00.043329 │      12 │
│ Glob scenarios │ Glob deep recursive        │         10 │ 0:00:03.404524 │ ± 0:00:00.244392 │ 0:00:04.028038 │   7,650 │
│ Glob scenarios │ Glob deep non-recursive    │         10 │ 0:00:00.033715 │ ± 0:00:00.002128 │ 0:00:00.036057 │      25 │
└────────────────┴────────────────────────────┴────────────┴────────────────┴──────────────────┴────────────────┴─────────┘
```

Also, CI timings are fickle, but we may have knocked a few minutes off the test suite when compared to `master`:
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/1799186/208732850-421c965c-4136-47df-a8ea-bb692abfdb1c.png">


