### PR TITLE
Updates to S3Client internals to pass extras and more

### DIFF
--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -148,6 +148,18 @@ class GSClient(Client):
         return self._is_file_or_dir(cloud_path) in ["file", "dir"]
 
     def _list_dir(self, cloud_path: GSPath, recursive=False) -> Iterable[Tuple[GSPath, bool]]:
+        # shortcut if listing all available buckets
+        if not cloud_path.bucket:
+            if recursive:
+                raise NotImplementedError(
+                    "Cannot recursively list all buckets and contents; you can get all the buckets then recursively list each separately."
+                )
+
+            yield from (
+                (self.CloudPath(f"gs://{str(b)}"), True) for b in self.client.list_buckets()
+            )
+            return
+
         bucket = self.client.bucket(cloud_path.bucket)
 
         prefix = cloud_path.blob

--- a/cloudpathlib/local/implementations/azure.py
+++ b/cloudpathlib/local/implementations/azure.py
@@ -25,12 +25,13 @@ class LocalAzureBlobClient(LocalClient):
             kwargs.get("account_url", None),
             os.getenv("AZURE_STORAGE_CONNECTION_STRING", None),
         ]
+        super().__init__(*args, **kwargs)
+
         if all(opt is None for opt in cred_opts):
             raise MissingCredentialsError(
                 "AzureBlobClient does not support anonymous instantiation. "
                 "Credentials are required; see docs for options."
             )
-        super().__init__(*args, **kwargs)
 
 
 LocalAzureBlobClient.AzureBlobPath = LocalAzureBlobClient.CloudPath  # type: ignore

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 
+from cloudpathlib.exceptions import CloudPathException
+
 
 from ..client import Client, register_client_class
 from ..cloudpath import implementation_registry
@@ -10,7 +12,7 @@ from .s3path import S3Path
 
 try:
     from boto3.session import Session
-    from boto3.s3.transfer import TransferConfig
+    from boto3.s3.transfer import TransferConfig, S3Transfer
     from botocore.config import Config
     from botocore.exceptions import ClientError
     import botocore.session
@@ -37,6 +39,7 @@ class S3Client(Client):
         endpoint_url: Optional[str] = None,
         boto3_transfer_config: Optional["TransferConfig"] = None,
         content_type_method: Optional[Callable] = mimetypes.guess_type,
+        extra_args: Optional[dict] = None,
     ):
         """Class constructor. Sets up a boto3 [`Session`](
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html).
@@ -52,9 +55,9 @@ class S3Client(Client):
             aws_secret_access_key (Optional[str]): AWS secret access key.
             aws_session_token (Optional[str]): Session key for your AWS account. This is only
                 needed when you are using temporarycredentials.
-            no_sign_request: (Optional[bool]): If `True`, credentials are not looked for and we use unsigned
+            no_sign_request (Optional[bool]): If `True`, credentials are not looked for and we use unsigned
                 requests to fetch resources. This will only allow access to public resources. This is equivalent
-                to `--no-sign-request` in the AWS CLI (https://docs.aws.amazon.com/cli/latest/reference/).
+                to `--no-sign-request` in the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/).
             botocore_session (Optional[botocore.session.Session]): An already instantiated botocore
                 Session.
             profile_name (Optional[str]): Profile name of a profile in a shared credentials file.
@@ -63,10 +66,14 @@ class S3Client(Client):
                 for downloaded files. If None, will use a temporary directory.
             endpoint_url (Optional[str]): S3 server endpoint URL to use for the constructed boto3 S3 resource and client.
                 Parameterize it to access a customly deployed S3-compatible object store such as MinIO, Ceph or any other.
-            boto3_transfer_config (Optional[dict]): Instantiated TransferConfig for managing s3 transfers.
-                (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig)
+            boto3_transfer_config (Optional[dict]): Instantiated TransferConfig for managing
+                [s3 transfers](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig)
             content_type_method (Optional[Callable]): Function to call to guess media type (mimetype) when
                 writing a file to the cloud. Defaults to `mimetypes.guess_type`. Must return a tuple (content type, content encoding).
+            extra_args (Optional[dict]): A dictionary of extra args passed to download, upload, and list functions as relevant. You
+                can include any keys supported by upload or download, and we will pass on only the relevant args. To see the extra
+                args that are supported look at the upload and download lists in the
+                [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer).
         """
         endpoint_url = endpoint_url or os.getenv("AWS_ENDPOINT_URL")
         if boto3_session is not None:
@@ -97,10 +104,32 @@ class S3Client(Client):
 
         self.boto3_transfer_config = boto3_transfer_config
 
+        if extra_args is None:
+            extra_args = {}
+
+        self._extra_args = extra_args
+        self.boto3_dl_extra_args = {
+            k: v for k, v in extra_args.items() if k in S3Transfer.ALLOWED_DOWNLOAD_ARGS
+        }
+        self.boto3_ul_extra_args = {
+            k: v for k, v in extra_args.items() if k in S3Transfer.ALLOWED_UPLOAD_ARGS
+        }
+
+        # listing ops (list_objects_v2, filter, delete) only accept these extras:
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+        self.boto3_list_extra_args = {
+            k: self._extra_args[k]
+            for k in ["RequestPayer", "ExpectedBucketOwner"]
+            if k in self._extra_args
+        }
+
         super().__init__(local_cache_dir=local_cache_dir, content_type_method=content_type_method)
 
     def _get_metadata(self, cloud_path: S3Path) -> Dict[str, Any]:
-        data = self.s3.ObjectSummary(cloud_path.bucket, cloud_path.key).get()
+        # get accepts all download extra args
+        data = self.s3.ObjectSummary(cloud_path.bucket, cloud_path.key).get(
+            **self.boto3_dl_extra_args
+        )
 
         return {
             "last_modified": data["LastModified"],
@@ -114,7 +143,9 @@ class S3Client(Client):
         local_path = Path(local_path)
         obj = self.s3.Object(cloud_path.bucket, cloud_path.key)
 
-        obj.download_file(str(local_path), Config=self.boto3_transfer_config)
+        obj.download_file(
+            str(local_path), Config=self.boto3_transfer_config, ExtraArgs=self.boto3_dl_extra_args
+        )
         return local_path
 
     def _is_file_or_dir(self, cloud_path: S3Path) -> Optional[str]:
@@ -123,30 +154,17 @@ class S3Client(Client):
             return "dir"
 
         # get first item by listing at least one key
-        s3_obj = self._s3_file_query(cloud_path)
-
-        if s3_obj is None:
-            return None
-
-        # since S3 only returns files when filtering objects:
-        # if the first item key is equal to the path key, this is a file
-        if s3_obj.key == cloud_path.key:
-
-            # "fake" directories on S3 can be created in the console UI
-            # these are 0-size keys that end in `/`
-            #  Ref: https://github.com/boto/boto3/issues/377
-            if s3_obj.key.endswith("/") and s3_obj.content_length == 0:
-                return "dir"
-            else:
-                return "file"
-        else:
-            return "dir"
+        return self._s3_file_query(cloud_path)
 
     def _exists(self, cloud_path: S3Path) -> bool:
         # check if this is a bucket
         if not cloud_path.key:
+            extra = {
+                k: self._extra_args[k] for k in ["ExpectedBucketOwner"] if k in self._extra_args
+            }
+
             try:
-                self.client.head_bucket(Bucket=cloud_path.bucket)
+                self.client.head_bucket(Bucket=cloud_path.bucket, **extra)
                 return True
             except ClientError:
                 return False
@@ -157,25 +175,44 @@ class S3Client(Client):
         """Boto3 query used for quick checks of existence and if path is file/dir"""
         # check if this is an object that we can access directly
         try:
-            obj = self.s3.Object(cloud_path.bucket, cloud_path.key)
-            obj.load()
-            return obj
+            # head_object accepts all download extra args (note: Object.load does not accept extra args so we do not use it for this check)
+            self.client.head_object(
+                Bucket=cloud_path.bucket,
+                Key=cloud_path.key.rstrip("/"),
+                **self.boto3_dl_extra_args,
+            )
+            return "file"
 
-        # else, confirm it is a dir by filtering to the first item under the prefix
-        except ClientError:
+        # else, confirm it is a dir by filtering to the first item under the prefix plus a "/"
+        except (ClientError, self.client.exceptions.NoSuchKey):
             key = cloud_path.key.rstrip("/") + "/"
 
             return next(
                 (
-                    obj
+                    "dir"  # always a dir if we find anything with this query
                     for obj in (
-                        self.s3.Bucket(cloud_path.bucket).objects.filter(Prefix=key).limit(1)
+                        self.s3.Bucket(cloud_path.bucket)
+                        .objects.filter(Prefix=key, **self.boto3_list_extra_args)
+                        .limit(1)
                     )
                 ),
                 None,
             )
 
     def _list_dir(self, cloud_path: S3Path, recursive=False) -> Iterable[Tuple[S3Path, bool]]:
+        # shortcut if listing all available buckets
+        if not cloud_path.bucket:
+            if recursive:
+                raise NotImplementedError(
+                    "Cannot recursively list all buckets and contents; you can get all the buckets then recursively list each separately."
+                )
+
+            yield from (
+                (self.CloudPath(f"s3://{b['Name']}"), True)
+                for b in self.client.list_buckets().get("Buckets", [])
+            )
+            return
+
         prefix = cloud_path.key
         if prefix and not prefix.endswith("/"):
             prefix += "/"
@@ -185,7 +222,10 @@ class S3Client(Client):
         paginator = self.client.get_paginator("list_objects_v2")
 
         for result in paginator.paginate(
-            Bucket=cloud_path.bucket, Prefix=prefix, Delimiter=("" if recursive else "/")
+            Bucket=cloud_path.bucket,
+            Prefix=prefix,
+            Delimiter=("" if recursive else "/"),
+            **self.boto3_list_extra_args,
         ):
             # yield everything in common prefixes as directories
             for result_prefix in result.get("CommonPrefixes", []):
@@ -238,27 +278,33 @@ class S3Client(Client):
                 CopySource={"Bucket": src.bucket, "Key": src.key},
                 Metadata=self._get_metadata(src).get("extra", {}),
                 MetadataDirective="REPLACE",
+                **self.boto3_ul_extra_args,
             )
 
         else:
             target = self.s3.Object(dst.bucket, dst.key)
-            target.copy({"Bucket": src.bucket, "Key": src.key})
+            target.copy(
+                {"Bucket": src.bucket, "Key": src.key},
+                ExtraArgs=self.boto3_dl_extra_args,
+                Config=self.boto3_transfer_config,
+            )
 
             if remove_src:
                 self._remove(src)
         return dst
 
     def _remove(self, cloud_path: S3Path, missing_ok: bool = True) -> None:
-        try:
-            obj = self.s3.Object(cloud_path.bucket, cloud_path.key)
+        file_or_dir = self._is_file_or_dir(cloud_path=cloud_path)
+        if file_or_dir == "file":
+            resp = self.s3.Object(cloud_path.bucket, cloud_path.key).delete(
+                **self.boto3_list_extra_args
+            )
+            if resp.get("ResponseMetadata").get("HTTPStatusCode") not in (204, 200):
+                raise CloudPathException(
+                    f"Delete operation failed for {cloud_path} with response: {resp}"
+                )
 
-            # will throw if not a file
-            obj.load()
-
-            resp = obj.delete()
-            assert resp.get("ResponseMetadata").get("HTTPStatusCode") == 204
-
-        except ClientError:
+        elif file_or_dir == "dir":
             # try to delete as a direcotry instead
             bucket = self.s3.Bucket(cloud_path.bucket)
 
@@ -266,20 +312,24 @@ class S3Client(Client):
             if prefix and not prefix.endswith("/"):
                 prefix += "/"
 
-            resp = bucket.objects.filter(Prefix=prefix).delete()
+            resp = bucket.objects.filter(Prefix=prefix, **self.boto3_list_extra_args).delete(
+                **self.boto3_list_extra_args
+            )
+            if resp[0].get("ResponseMetadata").get("HTTPStatusCode") not in (204, 200):
+                raise CloudPathException(
+                    f"Delete operation failed for {cloud_path} with response: {resp}"
+                )
 
-            # ensure directory deleted; if cloud_path did not exist at all
-            # resp will be [], so no need to check success
-            if resp:
-                assert resp[0].get("ResponseMetadata").get("HTTPStatusCode") == 200
-            else:
-                if not missing_ok:
-                    raise FileNotFoundError(f"File does not exist: {cloud_path}")
+        else:
+            if not missing_ok:
+                raise FileNotFoundError(
+                    f"Cannot delete file that does not exist: {cloud_path} (consider passing missing_ok=True)"
+                )
 
     def _upload_file(self, local_path: Union[str, os.PathLike], cloud_path: S3Path) -> S3Path:
         obj = self.s3.Object(cloud_path.bucket, cloud_path.key)
 
-        extra_args = {}
+        extra_args = self.boto3_ul_extra_args.copy()
 
         if self.content_type_method is not None:
             content_type, content_encoding = self.content_type_method(str(local_path))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -e .[all]
 
 black
-coverage<7
 flake8
 ipytest
 ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ testpaths = tests/
 addopts = --cov=cloudpathlib --cov-report=term --cov-report=html --cov-report=xml -n=auto
 
 [coverage:report]
-include = cloudpathlib/**.py
+include = cloudpathlib/**/*.py

--- a/tests/mock_clients/mock_azureblob.py
+++ b/tests/mock_clients/mock_azureblob.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 import shutil
@@ -37,6 +38,10 @@ def mocked_client_class_factory(test_dir: str):
 
         def get_container_client(self, container):
             return MockContainerClient(self.tmp_path, container_name=container)
+
+        def list_containers(self):
+            Container = namedtuple("Container", "name")
+            return [Container(name=DEFAULT_CONTAINER_NAME)]
 
     return MockBlobServiceClient
 

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -35,6 +35,9 @@ def mocked_client_class_factory(test_dir: str):
         def bucket(self, bucket):
             return MockBucket(self.tmp_path, bucket, client=self)
 
+        def list_buckets(self):
+            return [DEFAULT_GS_BUCKET_NAME]
+
     return MockClient
 
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -138,6 +138,17 @@ def test_iterdir(glob_test_dirs):
     )
 
 
+def test_list_buckets(rig):
+    # test we can list buckets
+    buckets = list(rig.path_class(f"{rig.path_class.cloud_prefix}").iterdir())
+    assert len(buckets) > 0
+
+    for b in buckets:
+        assert isinstance(b, rig.path_class)
+        assert b.drive != ""
+        assert b._no_prefix_no_drive == ""
+
+
 def test_glob(glob_test_dirs):
     cloud_root, local_root = glob_test_dirs
 


### PR DESCRIPTION
Updates a number of issues with S3Client internals, primarily the ability to pass `extra_args` that may be necessary to a user. This is primarily to address #254 and #180, which require passing extras around at the client level.

The current implementation assumes that all of the upload/download/listing operations will always use the same extras at the level of a client. This is reasonable for most of the extra args except some of the upload ones (Metadata, ContentType, etc.). For the ContentType and ContentEncoding, we already provide a separate means of setting these per-file.

Additionally, we add documentation for RequestPayer explicitly and then ExtraArgs generally.

Bonus:
 - #48 listing buckets across providers (and tests)
 - #271 Adds an example of a public bucket and caveat that listing permissions may not be available
 - Move the `super().__init__` calls in the azure objects so that credential errors don't result in additional warnings about missing properties
 - Simplify `_s3_file_query` logic now that API changes make it simpler to tell if something is a file or dir immediately
 - #212 Fix using `assert` in production code and status code checks that were too specific

Closes #48 
Closes #254 
Closes #180 
Closes #271
Closes #212