### PR TITLE
Fix globbing top level buckets and

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cloudpathlib Changelog
 
+## v0.12.1 (2023-01-04)
+
+ - Fix glob logic for buckets; add regression test; add error on globbing all buckets ([Issue #311](https://github.com/drivendataorg/cloudpathlib/issues/311), [PR #312](https://github.com/drivendataorg/cloudpathlib/pull/312))
+
 ## v0.12.0 (2022-12-30)
 
  - API Change: `S3Client` supports an `extra_args` kwarg now to pass extra args down to `boto3` functions; this enables Requester Pays bucket access and bucket encryption. (Issues [#254](https://github.com/drivendataorg/cloudpathlib/issues/254), [#180](https://github.com/drivendataorg/cloudpathlib/issues/180); [PR #307](https://github.com/drivendataorg/cloudpathlib/pull/307))

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/cloudpathlib",
     },
     url="https://github.com/drivendataorg/cloudpathlib",
-    version="0.12.0",
+    version="0.12.1",
 )

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -191,6 +191,25 @@ def test_glob(glob_test_dirs):
     )
 
 
+def test_glob_buckets(rig):
+    # CloudPath("s3://").glob("*") results in error
+    drive_level = rig.path_class(rig.path_class.cloud_prefix)
+
+    with pytest.raises(CloudPathNotImplementedError):
+        list(drive_level.glob("*"))
+
+    # CloudPath("s3://bucket").glob("*") should work
+    # bucket level glob returns correct results
+    # regression test for #311
+    bucket = rig.path_class(f"{rig.path_class.cloud_prefix}{rig.drive}")
+
+    first_result = next(bucket.glob("*"))
+
+    # assert all parts are unique
+    assert first_result.drive == rig.drive
+    assert len(first_result.parts) == len(set(first_result.parts))
+
+
 def test_glob_many_open_files(rig):
     # test_glob_many_open_files
     #  Adapted from: https://github.com/python/cpython/blob/7ffe7ba30fc051014977c6f393c51e57e71a6648/Lib/test/test_pathlib.py#L1697-L1712


### PR DESCRIPTION
#304 introduced a regression when globbing at the top level (`CloudPath("s3://bucket").glob("*")`) where the bucket was duplicated in the paths that glob yielded (`CloudPath("s3://bucket/bucket/file1.txt")` is retruned), which was reported in #311. Additionally, #311 mentions that `CloudPath("s3://").glob("*")` does not work as expected.

This PR adds two fixes:
 - Fix the path construction logic in `glob` to not duplicate the bucket at the top level.
 - Raise a not implemented error if globbing above a bucket level. Because of the way boto3 works, we would need to repeat our calls for each of the buckets to make globbing above a bucket work. This adds too much complexity. Instead, we give a friendly error that buckets can be listed with `iterdir` and `.glob` works within buckets.

Additionally we add a regression test and update setup.py and changelog to make a patch release to fix this bug.

