### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -177,10 +177,8 @@ class AzureBlobClient(Client):
         for o in container_client.list_blobs(name_starts_with=prefix):
             # get directory from this path
             for parent in PurePosixPath(o.name[len(prefix) :]).parents:
-
                 # if we haven't surfaced this directory already
                 if parent not in yielded_dirs and str(parent) != ".":
-
                     # skip if not recursive and this is beyond our depth
                     if not recursive and "/" in str(parent):
                         continue

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -1142,3 +1142,5 @@ class _CloudPathSelectable:
             _CloudPathSelectable(child, root._parents + [root._name], grand_children)
             for child, grand_children in root._all_children.items()
         )
+
+    _scandir = scandir  # Py 3.11 compatibility

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -173,10 +173,8 @@ class GSClient(Client):
         for o in bucket.list_blobs(prefix=prefix):
             # get directory from this path
             for parent in PurePosixPath(o.name[len(prefix) :]).parents:
-
                 # if we haven't surfaced thei directory already
                 if parent not in yielded_dirs and str(parent) != ".":
-
                     # skip if not recursive and this is beyond our depth
                     if not recursive and "/" in str(parent):
                         continue

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     description=("pathlib-style classes for cloud storage services"),
     extras_require=extra_reqs,

--- a/tests/mock_clients/utils.py
+++ b/tests/mock_clients/utils.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 
 def delete_empty_parents_up_to_root(path: Path, root: Path):
-
     for parent in path.parents:
         if parent == root:
             return


### PR DESCRIPTION
Python 3.11 was released in October 2022, so we should support it.

 - Adds 3.11 to support list in `setup.py`
 - Adds 3.11 to CI test matrix
 - Adds alias for `scandir` so tests pass with updated CPython internal pathlib implementation

Bonus: 
 - New version of `black` had some whitespace changes it needed to pass.

