### PR TITLE
Use Self type from PEP 673

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## v0.14.0 (Unreleased)
 
 - Changed to pyproject.toml-based build.
+- Changed type hints from custom type variable `DerivedCloudPath` to [`typing.Self`](https://docs.python.org/3/library/typing.html#typing.Self) ([PEP 673](https://docs.python.org/3/library/typing.html#typing.Self)). This adds a dependency on the [typing-extensions](https://pypi.org/project/typing-extensions/) backport package from Python versions lower than 3.11.
 
 ## v0.13.0 (2023-02-15)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.7"
-dependencies = ["importlib_metadata ; python_version < '3.8'"]
+dependencies = [
+  "importlib_metadata ; python_version < '3.8'",
+  "typing_extensions>4 ; python_version < '3.11'",
+]
 
 [project.optional-dependencies]
 azure = ["azure-storage-blob>=12"]


### PR DESCRIPTION
This PR replaces the custom type variable `DerivedCloudPath` with the special type `Self` added in Python 3.11 (adds `typing_extensions` backport dependency for older Python versions). This works in a functionally identical way as what we had before, as explained in the [official docs](https://docs.python.org/3/library/typing.html#typing.Self), but is a part of the standard library and much more readable. 

For more context, see [PEP 673](https://peps.python.org/pep-0673/).