### PR TITLE
Fix CloudPathMeta.__call__ return type

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -98,10 +98,11 @@ class CloudImplementation:
 implementation_registry: Dict[str, CloudImplementation] = defaultdict(CloudImplementation)
 
 
-def register_path_class(key: str) -> Callable:
-    T = TypeVar("T", bound=Type[CloudPath])
+CloudPathT = TypeVar("CloudPathT", bound="CloudPath")
 
-    def decorator(cls: Type[T]) -> Type[T]:
+
+def register_path_class(key: str) -> Callable[[Type[CloudPathT]], Type[CloudPathT]]:
+    def decorator(cls: Type[CloudPathT]) -> Type[CloudPathT]:
         if not issubclass(cls, CloudPath):
             raise TypeError("Only subclasses of CloudPath can be registered.")
         implementation_registry[key]._path_class = cls
@@ -112,7 +113,7 @@ def register_path_class(key: str) -> Callable:
 
 
 class CloudPathMeta(abc.ABCMeta):
-    def __call__(cls, cloud_path, *args, **kwargs):
+    def __call__(cls, cloud_path: Union[str, CloudPathT], *args, **kwargs) -> CloudPathT:
         # cls is a class that is the instance of this metaclass, e.g., CloudPath
 
         # Dispatch to subclass if base CloudPath


### PR DESCRIPTION
Since `pyright==1.1.307`, instances of the subclasses of `CloudPath` stopped being recognized as instances of their own class; a possible fix is to type hint `CloudPathMeta.__call__`, but it creates a host of `mypy` errors (5)... 

Here is the typing bug starting in the newest version of pyright and the fix with this proposed change:

```python
import cloudpathlib


# before
x = cloudpathlib.S3Path("s3://bucket/key")
# reveal_type(x)  # Pylance: Type of "x" is "CloudPath | Unknown | Self@__new__"
y = cloudpathlib.CloudPath(x)
# reveal_type(y)  # Pylance: Type of "y" is "CloudPath | Unknown | Self@__new__"

# after
x = cloudpathlib.S3Path("s3://bucket/key")
reveal_type(x)  # Pylance: Type of "x" is "S3Path"
y = cloudpathlib.CloudPath(x)
reveal_type(y)  # Pylance: Type of "y" is "S3Path"
```

These are the mypy bugs that arise:
```console
$ mypy cloudpathlib
cloudpathlib/cloudpath.py:127: error: Too many arguments for "__new__" of "object"  [call-arg]
cloudpathlib/cloudpath.py:129: error: Value of type variable "Self" of "__init__" of "CloudPath" cannot be "object"  [type-var]
cloudpathlib/cloudpath.py:130: error: Incompatible return value type (got "CloudPath", expected "CloudPathT")  [return-value]
cloudpathlib/cloudpath.py:141: error: Argument 1 to "__new__" of "ABCMeta" has incompatible type "CloudPathMeta"; expected "Type[<nothing>]"  [arg-type]
cloudpathlib/cloudpath.py:141: error: Argument 2 to "__new__" of "ABCMeta" has incompatible type "Union[str, CloudPathT]"; expected "str"  [arg-type]
```

I'm really not sure how to begin to solve these... it seems like they were there to begin with but weren't being raised (due to the lack of typing present on the signature, I assume)... I could definitely use some help in solving these. Would we consider `type: ignore`?