### PR TITLE
Stream to and from Azure

### DIFF
--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -266,7 +266,8 @@ class AzureBlobClient(Client):
 
         content_settings = ContentSettings(**extra_args)
 
-        blob.upload_blob(Path(local_path).read_bytes(), overwrite=True, content_settings=content_settings)  # type: ignore
+        with open(Path(local_path), "rb") as data:
+            blob.upload_blob(data, overwrite=True, content_settings=content_settings)  # type: ignore
 
         return cloud_path
 

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -124,7 +124,8 @@ class AzureBlobClient(Client):
 
         local_path.parent.mkdir(exist_ok=True, parents=True)
 
-        local_path.write_bytes(download_stream.content_as_bytes())
+        with open(local_path, "wb") as data:
+            download_stream.readinto(data)
 
         return local_path
 


### PR DESCRIPTION
Currently, Azure is implemented without streams. This means that when uploading a file, the full file is first read into memory, before it is actually uploaded. The same goes for downloads.

This PR changes that by using streams.