### PR TITLE
Make CloudPath.is_valid_cloudpath a TypeGuard

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -35,6 +35,10 @@ from typing import (
 from urllib.parse import urlparse
 from warnings import warn
 
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extensions import TypeGuard
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -258,8 +262,20 @@ class CloudPath(metaclass=CloudPathMeta):
     def _no_prefix_no_drive(self) -> str:
         return self._str[len(self.cloud_prefix) + len(self.drive) :]
 
+    @overload
     @classmethod
-    def is_valid_cloudpath(cls, path: Union[str, "CloudPath"], raise_on_error=False) -> bool:
+    def is_valid_cloudpath(cls, path: "CloudPath", raise_on_error: bool = ...) -> TypeGuard[Self]:
+        ...
+
+    @overload
+    @classmethod
+    def is_valid_cloudpath(cls, path: str, raise_on_error: bool = ...) -> bool:
+        ...
+
+    @classmethod
+    def is_valid_cloudpath(
+        cls, path: Union[str, "CloudPath"], raise_on_error: bool = False
+    ) -> Union[bool, TypeGuard[Self]]:
         valid = str(path).lower().startswith(cls.cloud_prefix.lower())
 
         if raise_on_error and not valid:


### PR DESCRIPTION
This is actually a `TypeGuard` I had implemented in my own codebase, but I recently realized it is doing exactly the same thing as `is_valid_cloudpath`. This allows us to infer that `CloudPath`s are the same type of object as the class `is_valid_cloudpath` is called on!

```python
import cloudpathlib


def get_cloudpath_str() -> str:
    return "s3://other/path"


def get_cloudpath() -> cloudpathlib.CloudPath:
    return cloudpathlib.CloudPath("s3://other/path")


other_path_str = get_cloudpath_str()
if cloudpathlib.S3Path.is_valid_cloudpath(other_path_str):
    reveal_type(other_path_str)
    # no change from before:
    # pyright : Type of "other_path_str" is "str"
    # mypy : Revealed type is "builtins.str"

other_path = get_cloudpath()
if cloudpathlib.S3Path.is_valid_cloudpath(other_path):
    reveal_type(other_path)
    # before:
    # pyright : Type of "other_path" is "CloudPath"
    # mypy : Revealed type is "cloudpathlib.cloudpath.CloudPath"

    # this PR:
    # pyright : Type of "other_path" is "S3Path"
    # mypy : Revealed type is "Self`2"

```

I opened an issue with mypy regarding this strange behavior which only seems to arise on `TypeGuard` methods: https://github.com/python/mypy/issues/15401