### PR TITLE
Allow joining CloudPath with strings representing absolute paths

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -688,8 +688,8 @@ class CloudPath(metaclass=CloudPathMeta):
         if not isinstance(other, (str, PurePosixPath)):
             raise TypeError(f"Can only join path {repr(self)} with strings or posix paths.")
 
-        # Special handling is needed, because pathlib's `/` operator ignores all previous segments, when `other` is
-        # an absolute path. That means bucket name would be removed.
+        # Special handling is needed, because pathlib's `/` operator ignores all previous segments,
+        # when `other` is an absolute path. That means bucket name would be removed.
         other_str = str(other)
         if other_str.startswith('/'):
             other = other_str.lstrip('/')

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -688,6 +688,12 @@ class CloudPath(metaclass=CloudPathMeta):
         if not isinstance(other, (str, PurePosixPath)):
             raise TypeError(f"Can only join path {repr(self)} with strings or posix paths.")
 
+        # Special handling is needed, because pathlib's `/` operator ignores all previous segments, when `other` is
+        # an absolute path. That means bucket name would be removed.
+        other_str = str(other)
+        if other_str.startswith('/'):
+            other = other_str.lstrip('/')
+
         return self._dispatch_to_path("__truediv__", other)
 
     def joinpath(self, *args: Union[str, os.PathLike]) -> Self:

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -22,6 +22,28 @@ def test_s3path_properties(path_class):
     assert p2.bucket == "bucket"
 
 
+@pytest.mark.parametrize("path_class", [S3Path, LocalS3Path])
+def test_s3path_properties_with_relative_paths(path_class):
+    p = path_class("s3://bucket") / "foo"
+    assert p.key == "foo"
+    assert p.bucket == "bucket"
+
+    p2 = path_class("s3://bucket/") / "foo/bar"
+    assert p2.key == "foo/bar"
+    assert p2.bucket == "bucket"
+
+
+@pytest.mark.parametrize("path_class", [S3Path, LocalS3Path])
+def test_s3path_properties_with_absolute_paths(path_class):
+    p = path_class("s3://bucket") / "/foo"
+    assert p.key == "foo"
+    assert p.bucket == "bucket"
+
+    p2 = path_class("s3://bucket/") / "/foo/bar"
+    assert p2.key == "foo/bar"
+    assert p2.bucket == "bucket"
+
+
 def test_transfer_config(s3_rig, tmp_path):
     transfer_config = TransferConfig(multipart_threshold=50)
     client = s3_rig.client_class(boto3_transfer_config=transfer_config)

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -43,6 +43,14 @@ def test_s3path_properties_with_absolute_paths(path_class):
     assert p2.key == "foo/bar"
     assert p2.bucket == "bucket"
 
+    p3 = path_class("s3://bucket/fee") / "/foo"
+    assert p3.key == "fee/foo"
+    assert p3.bucket == "bucket"
+
+    p4 = path_class("s3://bucket/fee/") / "/foo/bar"
+    assert p4.key == "fee/foo/bar"
+    assert p4.bucket == "bucket"
+
 
 def test_transfer_config(s3_rig, tmp_path):
     transfer_config = TransferConfig(multipart_threshold=50)


### PR DESCRIPTION
I added test cases that check path appending with `/` for S3 paths and them modified `__truediv__` to handle appending absolute paths to `CloudPath` values.

@pjbull Should I add similar tests to `test_gs_specific.py` and `test_azure_specific.py`, or is there a single test file that could be used to check it for all providers at once?

Closes #344 