### PR TITLE
pydantic compatibility warning

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cloudpathlib Changelog
 
+## v0.15.1 (2023-06-16)
+ - Warn if Pydantic >= 2.0.0 since we are not yet compatible.
+
+
 ## v0.15.0 (2023-06-16)
 
 - Changed return type for `CloudPathMeta.__call__` to fix problems with pyright/pylance ([PR #330](https://github.com/drivendataorg/cloudpathlib/pull/330))

--- a/cloudpathlib/__init__.py
+++ b/cloudpathlib/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from warnings import warn
 
 from .anypath import AnyPath
 from .azure.azblobclient import AzureBlobClient
@@ -30,3 +31,22 @@ __all__ = [
     "S3Client",
     "S3Path",
 ]
+
+
+class PydanticVersionWarning(UserWarning):
+    message = (
+        "This version of cloudpathlib is only compatible with pydantic<2.0.0. "
+        "You can ignore this warning if none of your pydantic models are "
+        "annotated with cloudpathlib types."
+    )
+
+
+try:
+    import pydantic
+    from packaging.version import parse
+
+    if parse(pydantic.__version__) >= parse("2.0.0"):
+        warn(PydanticVersionWarning(PydanticVersionWarning.message))
+
+except ImportError:
+    pass

--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -2,6 +2,13 @@
 
 ## Pydantic
 
+!!! warning
+
+    As of version `0.15.1`, `cloudpathlib` is not compatible with
+    version `2.0.0` or greater of Pydantic. If you want to annotate
+    your pydantic models with cloudpathlib types, you need to use
+    `pydantic<2`.
+
 `cloudpathlib` integrates with [Pydantic](https://pydantic-docs.helpmanual.io/)'s data validation. You can declare fields with cloud path classes, and Pydantic's validation mechanisms will run inputs through the cloud path's constructor.
 
 ```python

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
           - cloudpathlib.local: "api-reference/local.md"
 
 markdown_extensions:
+  - admonition
   - pymdownx.highlight
   - pymdownx.superfences
   - toc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cloudpathlib"
-version = "0.15.0"
+version = "0.15.1"
 description = "pathlib-style classes for cloud storage services."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ nbautoexport
 pandas
 pillow
 psutil
-pydantic
+pydantic<2
 pytest
 pytest-cases
 pytest-cov

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -90,6 +90,9 @@ class MockBoto3Object:
 
     def download_file(self, to_path, Config=None, ExtraArgs=None):
         to_path = Path(to_path)
+
+        to_path.parent.mkdir(parents=True, exist_ok=True)
+
         to_path.write_bytes(self.path.read_bytes())
         # track config to make sure it's used in tests
         self.resource.download_config = Config


### PR DESCRIPTION
Actual migration to support 2.0.0 is going to be a bunch more work, so adding just the warning for the time being.

```python
❯ pip list | grep pydantic
pydantic                   1.10.11

❯python
Python 3.11.4 (main, Jul  5 2023, 08:41:25) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import cloudpathlib
>>> quit()

❯ pip install -U pydantic
...
Successfully installed pydantic-2.0.2

❯ python
Python 3.11.4 (main, Jul  5 2023, 08:41:25) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import cloudpathlib
/Users/bull/code/cloudpathlib/cloudpathlib/__init__.py:49: PydanticVersionWarning: This version of cloudpathlib is only compatible with pydantic<2.0.0. You can ignore this warning if none of your pydantic models are annotated with cloudpathlib types.
  warn(PydanticVersionWarning(PydanticVersionWarning.message))
```

Docs preview:
https://deploy-preview-348--gallant-agnesi-5f7bb3.netlify.app/integrations/
<img width="600" alt="image" src="https://github.com/drivendataorg/cloudpathlib/assets/1799186/0661c744-b253-4b6a-9cf5-ced147b37abe">
