### PR TITLE
Update write_text to include newline variable

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
  - Add "CloudPath" as return type on `__init__` for mypy issues. ([Issue #179](https://github.com/drivendataorg/cloudpathlib/issues/179), [PR #342](https://github.com/drivendataorg/cloudpathlib/pull/342))
  - Add `with_stem` to all path types when python version supports it (>=3.9). ([Issue #287](https://github.com/drivendataorg/cloudpathlib/issues/287), [PR #290](https://github.com/drivendataorg/cloudpathlib/pull/290), thanks to [@Gilthans](https://github.com/Gilthans)) 
+ - Add `newline` parameter to the `write_text` method to align to `pathlib` functionality as of Python 3.10. [PR #362]https://github.com/drivendataorg/cloudpathlib/pull/362), thanks to [@pricemg](https://github.com/pricemg).
 
 ## v0.15.1 (2023-07-12)
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -2,7 +2,6 @@ import abc
 from collections import defaultdict
 import collections.abc
 from contextlib import contextmanager
-import io
 import os
 from pathlib import (  # type: ignore
     Path,
@@ -636,8 +635,6 @@ class CloudPath(metaclass=CloudPathMeta):
         """
         if not isinstance(data, str):
             raise TypeError("data must be str, not %s" % data.__class__.__name__)
-
-        encoding = io.text_encoding(encoding)
 
         with self.open(mode="w", encoding=encoding, errors=errors, newline=newline) as f:
             return f.write(data)

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -2,6 +2,7 @@ import abc
 from collections import defaultdict
 import collections.abc
 from contextlib import contextmanager
+import io
 import os
 from pathlib import (  # type: ignore
     Path,
@@ -626,15 +627,20 @@ class CloudPath(metaclass=CloudPathMeta):
         data: str,
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
+        newline: Optional[str] = None,
     ) -> int:
         """Open the file in text mode, write to it, and close the file.
 
         NOTE: vendored from pathlib since we override open
         https://github.com/python/cpython/blob/3.8/Lib/pathlib.py#L1244-L1252
+        https://github.com/python/cpython/blob/3.10/Lib/pathlib.py#L1146-L1155
         """
         if not isinstance(data, str):
             raise TypeError("data must be str, not %s" % data.__class__.__name__)
-        with self.open(mode="w", encoding=encoding, errors=errors) as f:
+
+        encoding = io.text_encoding(encoding)
+
+        with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
             return f.write(data)
 
     def read_bytes(self) -> bytes:

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -632,7 +632,6 @@ class CloudPath(metaclass=CloudPathMeta):
         """Open the file in text mode, write to it, and close the file.
 
         NOTE: vendored from pathlib since we override open
-        https://github.com/python/cpython/blob/3.8/Lib/pathlib.py#L1244-L1252
         https://github.com/python/cpython/blob/3.10/Lib/pathlib.py#L1146-L1155
         """
         if not isinstance(data, str):

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -639,7 +639,7 @@ class CloudPath(metaclass=CloudPathMeta):
 
         encoding = io.text_encoding(encoding)
 
-        with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
+        with self.open(mode="w", encoding=encoding, errors=errors, newline=newline) as f:
             return f.write(data)
 
     def read_bytes(self) -> bytes:


### PR DESCRIPTION
As of python3.10 `write_text` in the `pathlib` module also has the optional argument `newline` ([code](https://github.com/python/cpython/blob/fc382d3dd08709a9dc5000a691d3a74f7b4a99ac/Lib/pathlib.py#L1146)). 

Adding in the functionality to the `open` call.