### PR TITLE
Fix an error when incomplete S3Client is destroyed (#373)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,11 @@
 # cloudpathlib Changelog
 
+## Unreleased
+- Fix `S3Client` cleanup via `Client.__del__` when `S3Client` encounters an exception during initialization. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), PR [#373](https://github.com/drivendataorg/cloudpathlib/pull/373))
+
 ## v0.16.0 (2023-10-09)
  - Add "CloudPath" as return type on `__init__` for mypy issues. ([Issue #179](https://github.com/drivendataorg/cloudpathlib/issues/179), [PR #342](https://github.com/drivendataorg/cloudpathlib/pull/342))
- - Add `with_stem` to all path types when python version supports it (>=3.9). ([Issue #287](https://github.com/drivendataorg/cloudpathlib/issues/287), [PR #290](https://github.com/drivendataorg/cloudpathlib/pull/290), thanks to [@Gilthans](https://github.com/Gilthans)) 
+ - Add `with_stem` to all path types when python version supports it (>=3.9). ([Issue #287](https://github.com/drivendataorg/cloudpathlib/issues/287), [PR #290](https://github.com/drivendataorg/cloudpathlib/pull/290), thanks to [@Gilthans](https://github.com/Gilthans))
  - Add `newline` parameter to the `write_text` method to align to `pathlib` functionality as of Python 3.10. [PR #362](https://github.com/drivendataorg/cloudpathlib/pull/362), thanks to [@pricemg](https://github.com/pricemg).
  - Add support for Python 3.12 ([PR #364](https://github.com/drivendataorg/cloudpathlib/pull/364))
  - Add `CLOUDPATHLIB_LOCAL_CACHE_DIR` env var for setting local_cache_dir default for clients ([Issue #352](https://github.com/drivendataorg/cloudpathlib/issues/352), [PR #357](https://github.com/drivendataorg/cloudpathlib/pull/357))

--- a/cloudpathlib/client.py
+++ b/cloudpathlib/client.py
@@ -85,7 +85,7 @@ class Client(abc.ABC, Generic[BoundedCloudPath]):
     def __del__(self) -> None:
         # remove containing dir, even if a more aggressive strategy
         # removed the actual files
-        if self.file_cache_mode in [
+        if getattr(self, "file_cache_mode", None) in [
             FileCacheMode.tmp_dir,
             FileCacheMode.close_file,
             FileCacheMode.cloudpath_object,


### PR DESCRIPTION
Repo-local PR for live tests of #373

------------

* Fix an error when incomplete S3Client is destroyed

If an error occurs during initialization of the S3Client instance, the initializer for the Client superclass is never called. This could happen, for example, when the S3Client has a bad profile name passed which botocore doesn't understand. When the remainder of the class is garbage collected (for example, at interpreter shutdown), Python calls the __del__ method of the Client superclass. The specific error is that the file_cache_mode attribute is not set because the superclass initializer is not called in the S3Client initializer if an error occurs during S3 session setup.

This change uses getattr with a default value to avoid the AttributeError in the __del__ method.

Closes #372