### PR TITLE
Longer sleep time for flaky test

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -178,7 +178,7 @@ def test_persistent_mode(rig: CloudProviderTestRig, tmpdir):
 
 
 def test_interaction_with_local_cache_dir(rig: CloudProviderTestRig, tmpdir):
-    default_sleep = 0.5  # sometimes GH runners are slow and fail saying dir doesn't exist
+    default_sleep = 1.0  # sometimes GH runners are slow and fail saying dir doesn't exist
 
     # cannot instantiate persistent without local file dir
     with pytest.raises(InvalidConfigurationException):


### PR DESCRIPTION
Makes a flaky test sleepier.

Sometimes for this test, we see a race condition with the OS where the file in the cache doesn't exist yet. Make the sleep time in the test longer to avoid this scenario.