### PR TITLE
Fix flaky test test_interaction_with_local_cache_dir

### DIFF
--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 import shutil
 from tempfile import TemporaryDirectory
+from time import sleep
 
 from google.api_core.exceptions import NotFound
 

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -59,6 +59,13 @@ class MockBlob:
 
         to_path.parent.mkdir(exist_ok=True, parents=True)
 
+        # sometimes on GH runners on Windows return from mkdir
+        # before the directory actually exists.
+        waits = 10
+        while not to_path.parent.exists() and waits > 0:
+            sleep(0.1)
+            waits -= 1
+
         to_path.write_bytes(from_path.read_bytes())
 
     def patch(self):

--- a/tests/mock_clients/mock_s3.py
+++ b/tests/mock_clients/mock_s3.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 import shutil
 from tempfile import TemporaryDirectory
+from time import sleep
 
 from boto3.session import Session
 from botocore.exceptions import ClientError
@@ -92,6 +93,13 @@ class MockBoto3Object:
         to_path = Path(to_path)
 
         to_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # sometimes on GH runners on Windows return from mkdir
+        # before the directory actually exists.
+        waits = 10
+        while not to_path.parent.exists() and waits > 0:
+            sleep(0.1)
+            waits -= 1
 
         to_path.write_bytes(self.path.read_bytes())
         # track config to make sure it's used in tests

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -178,8 +178,6 @@ def test_persistent_mode(rig: CloudProviderTestRig, tmpdir):
 
 
 def test_interaction_with_local_cache_dir(rig: CloudProviderTestRig, tmpdir):
-    default_sleep = 1.0  # sometimes GH runners are slow and fail saying dir doesn't exist
-
     # cannot instantiate persistent without local file dir
     with pytest.raises(InvalidConfigurationException):
         client = rig.client_class(
@@ -201,7 +199,6 @@ def test_interaction_with_local_cache_dir(rig: CloudProviderTestRig, tmpdir):
 
     # download from cloud into the cache
     # must use open for close_file mode
-    sleep(default_sleep)
     with cp.open("r") as f:
         _ = f.read()
 
@@ -217,7 +214,6 @@ def test_interaction_with_local_cache_dir(rig: CloudProviderTestRig, tmpdir):
     assert cp.client.file_cache_mode == FileCacheMode.cloudpath_object
 
     # download from cloud into the cache
-    sleep(default_sleep)  # test can be flaky saying that the cache dir doesn't exist yet
     with cp.open("r") as f:
         _ = f.read()
 
@@ -236,7 +232,6 @@ def test_interaction_with_local_cache_dir(rig: CloudProviderTestRig, tmpdir):
     assert cp.client.file_cache_mode == FileCacheMode.tmp_dir
 
     # download from cloud into the cache
-    sleep(default_sleep)  # test can be flaky saying that the cache dir doesn't exist yet
     with cp.open("r") as f:
         _ = f.read()
 


### PR DESCRIPTION
Seems related to maybe a case condition between `mkdir` and then `write_bytes`. Added a smart sleep up to 1s.