### PR TITLE
Skip mtime checks during upload when force_overwrite_to_cloud is set

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix `S3Client` cleanup via `Client.__del__` when `S3Client` encounters an exception during initialization. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), PR [#373](https://github.com/drivendataorg/cloudpathlib/pull/373))
+- Skip mtime checks during upload when force_overwrite_to_cloud is set to improve upload performance. (Issue [#379](https://github.com/drivendataorg/cloudpathlib/issues/379), PR [#380](https://github.com/drivendataorg/cloudpathlib/pull/380), thanks to [@Gilthans](https://github.com/Gilthans))
 
 ## v0.16.0 (2023-10-09)
  - Add "CloudPath" as return type on `__init__` for mypy issues. ([Issue #179](https://github.com/drivendataorg/cloudpathlib/issues/179), [PR #342](https://github.com/drivendataorg/cloudpathlib/pull/342))

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -1172,17 +1172,21 @@ class CloudPath(metaclass=CloudPathMeta):
         """Uploads file at `local_path` to the cloud if there is not a newer file
         already there.
         """
+        if force_overwrite_to_cloud:
+            # If we are overwriting no need to perform any checks, so we can save time
+            self.client._upload_file(
+                local_path,
+                self,
+            )
+            return self
+
         try:
             stats = self.stat()
         except NoStatError:
             stats = None
 
-        # if cloud does not exist or local is newer or we are overwriting, do the upload
-        if (
-            not stats  # cloud does not exist
-            or (local_path.stat().st_mtime > stats.st_mtime)
-            or force_overwrite_to_cloud
-        ):
+        # if cloud does not exist or local is newer, do the upload
+        if not stats or (local_path.stat().st_mtime > stats.st_mtime):
             self.client._upload_file(
                 local_path,
                 self,


### PR DESCRIPTION
Live tests for (#380)

------------------------------------

* Skip mtime checks during upload when force_overwrite_to_cloud is set

* Lint fix

* Updated HISTORY.md

DESCRIPTION_HERE

Closes #ISSUE

----------------

Contributor checklist:

 - [ ] I have read and understood `CONTRIBUTING.md`
 - [ ] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [ ] Confirmed PR is rebased onto the latest base
 - [ ] Confirmed failure before change and success after change
 - [ ] Any generic new functionality is replicated across cloud providers if necessary
 - [ ] Tested manually against live server backend for at least one provider
 - [ ] Added tests for any new functionality
 - [ ] Linting passes locally
 - [ ] Tests pass locally
 - [ ] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.