### PR TITLE
WIP: Implement sliced downloads in GSClient

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Fix `S3Client` cleanup via `Client.__del__` when `S3Client` encounters an exception during initialization. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), PR [#373](https://github.com/drivendataorg/cloudpathlib/pull/373))
 - Skip mtime checks during upload when force_overwrite_to_cloud is set to improve upload performance. (Issue [#379](https://github.com/drivendataorg/cloudpathlib/issues/379), PR [#380](https://github.com/drivendataorg/cloudpathlib/pull/380), thanks to [@Gilthans](https://github.com/Gilthans))
+- Implement sliced downloads in GSClient. (Issue [#387](https://github.com/drivendataorg/cloudpathlib/issues/387), PR [#389](https://github.com/drivendataorg/cloudpathlib/pull/389))
 
 ## v0.16.0 (2023-10-09)
  - Add "CloudPath" as return type on `__init__` for mypy issues. ([Issue #179](https://github.com/drivendataorg/cloudpathlib/issues/179), [PR #342](https://github.com/drivendataorg/cloudpathlib/pull/342))

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -1,8 +1,8 @@
+from datetime import datetime
 import mimetypes
 import os
-from datetime import datetime
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Optional, TYPE_CHECKING, Tuple, Union
 
 from ..client import Client, register_client_class
 from ..cloudpath import implementation_registry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from .mock_clients.mock_azureblob import mocked_client_class_factory, DEFAULT_CO
 from .mock_clients.mock_gs import (
     mocked_client_class_factory as mocked_gsclient_class_factory,
     DEFAULT_GS_BUCKET_NAME,
+    MockTransferManager,
 )
 from .mock_clients.mock_s3 import mocked_session_class_factory, DEFAULT_S3_BUCKET_NAME
 
@@ -183,6 +184,11 @@ def gs_rig(request, monkeypatch, assets_dir):
             cloudpathlib.gs.gsclient,
             "StorageClient",
             mocked_gsclient_class_factory(test_dir),
+        )
+        monkeypatch.setattr(
+            cloudpathlib.gs.gsclient,
+            "transfer_manager",
+            MockTransferManager,
         )
 
     rig = CloudProviderTestRig(

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -168,3 +168,19 @@ class MockHTTPIterator:
     @property
     def prefixes(self):
         return self.sub_directories
+
+
+class MockTransferManager:
+    @staticmethod
+    def download_chunks_concurrently(
+        blob,
+        filename,
+        chunk_size=32 * 1024 * 1024,
+        download_kwargs=None,
+        deadline=None,
+        worker_type="process",
+        max_workers=8,
+        *,
+        crc32c_checksum=True,
+    ):
+        blob.download_to_filename(filename)

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -1,6 +1,6 @@
+import shutil
 from datetime import datetime
 from pathlib import Path, PurePosixPath
-import shutil
 from tempfile import TemporaryDirectory
 
 from google.api_core.exceptions import NotFound
@@ -64,6 +64,21 @@ class MockBlob:
     def patch(self):
         if "updated" in self.metadata:
             (self.bucket / self.name).touch()
+
+    def reload(
+        self,
+        client=None,
+        projection="noAcl",
+        if_etag_match=None,
+        if_etag_not_match=None,
+        if_generation_match=None,
+        if_generation_not_match=None,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        timeout=None,
+        retry=None,
+    ):
+        pass
 
     def upload_from_filename(self, filename, content_type=None):
         data = Path(filename).read_bytes()

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -1,6 +1,6 @@
-import shutil
 from datetime import datetime
 from pathlib import Path, PurePosixPath
+import shutil
 from tempfile import TemporaryDirectory
 
 from google.api_core.exceptions import NotFound

--- a/tests/test_gs_specific.py
+++ b/tests/test_gs_specific.py
@@ -15,8 +15,9 @@ def test_gspath_properties(path_class):
     assert p2.bucket == "mybucket"
 
 
-def test_concurrent_download(gs_rig, tmp_path):
-    client = gs_rig.client_class(download_chunks_concurrently_kwargs={})
+@pytest.mark.parametrize("worker_type", ["process", "thread"])
+def test_concurrent_download(gs_rig, tmp_path, worker_type):
+    client = gs_rig.client_class(download_chunks_concurrently_kwargs={"worker_type": worker_type})
     p = gs_rig.create_cloud_path("dir_0/file0_0.txt", client=client)
     dl_dir = tmp_path
     assert not (dl_dir / p.name).exists()

--- a/tests/test_gs_specific.py
+++ b/tests/test_gs_specific.py
@@ -1,7 +1,7 @@
 import pytest
 
-from cloudpathlib import GSClient, GSPath
-from cloudpathlib.local import LocalGSClient, LocalGSPath
+from cloudpathlib import GSPath
+from cloudpathlib.local import LocalGSPath
 
 
 @pytest.mark.parametrize("path_class", [GSPath, LocalGSPath])

--- a/tests/test_gs_specific.py
+++ b/tests/test_gs_specific.py
@@ -1,7 +1,7 @@
 import pytest
 
-from cloudpathlib import GSPath
-from cloudpathlib.local import LocalGSPath
+from cloudpathlib import GSClient, GSPath
+from cloudpathlib.local import LocalGSClient, LocalGSPath
 
 
 @pytest.mark.parametrize("path_class", [GSPath, LocalGSPath])
@@ -13,3 +13,12 @@ def test_gspath_properties(path_class):
     p2 = path_class("gs://mybucket/")
     assert p2.blob == ""
     assert p2.bucket == "mybucket"
+
+
+def test_concurrent_download(gs_rig, tmp_path):
+    client = gs_rig.client_class(download_chunks_concurrently_kwargs={})
+    p = gs_rig.create_cloud_path("dir_0/file0_0.txt", client=client)
+    dl_dir = tmp_path
+    assert not (dl_dir / p.name).exists()
+    p.download_to(dl_dir)
+    assert (dl_dir / p.name).is_file()


### PR DESCRIPTION
Implements sliced object downloads in GSClient using `google.cloud.storage.transfer_manager` as documented [here](https://cloud.google.com/storage/docs/sliced-object-downloads).

Closes #387 

----------------

Contributor checklist:

 - [x] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [x] Confirmed PR is rebased onto the latest base
 - [x] Confirmed failure before change and success after change
 - [x] Any generic new functionality is replicated across cloud providers if necessary
 - [x] Tested manually against live server backend for at least one provider
 - [x] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [x] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.