### PR TITLE
Set canonical_version in mike configuration

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -70,6 +70,8 @@ plugins:
             heading_level: 2
             group_by_category: true
             show_category_heading: true
+  - mike:
+      canonical_version: stable
 
 extra:
   version:


### PR DESCRIPTION
Currently, any particular version of the docs has header metadata like

```html
<link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/authentication/">
```
that references itself. 

This configuration change will cause it to instead set it to

```html
<link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
```

This will only change for future deploys going forward. I've tested this by manually doing a staged deploy for `latest`, and it seems to work, and I will manually edit existing deploys on the `gh-pages` branch. (See #399) 

Closes #397 