### PR TITLE
Update canonical link in previous versions built docs

### DIFF
--- a/stable/anypath-polymorphism/index.html
+++ b/stable/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       
         <link rel="prev" href="../caching/">

--- a/stable/api-reference/anypath/index.html
+++ b/stable/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       
         <link rel="prev" href="../cloudpath/">

--- a/stable/api-reference/azblobclient/index.html
+++ b/stable/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       
         <link rel="prev" href="../anypath/">

--- a/stable/api-reference/azblobpath/index.html
+++ b/stable/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       
         <link rel="prev" href="../azblobclient/">

--- a/stable/api-reference/client/index.html
+++ b/stable/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       
         <link rel="prev" href="../gspath/">

--- a/stable/api-reference/cloudpath/index.html
+++ b/stable/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       
         <link rel="prev" href="../../changelog/">

--- a/stable/api-reference/enums/index.html
+++ b/stable/api-reference/enums/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/enums/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/enums/">
       
       
         <link rel="prev" href="../client/">

--- a/stable/api-reference/exceptions/index.html
+++ b/stable/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       
         <link rel="prev" href="../enums/">

--- a/stable/api-reference/gsclient/index.html
+++ b/stable/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       
         <link rel="prev" href="../s3path/">

--- a/stable/api-reference/gspath/index.html
+++ b/stable/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       
         <link rel="prev" href="../gsclient/">

--- a/stable/api-reference/local/index.html
+++ b/stable/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       
         <link rel="prev" href="../exceptions/">

--- a/stable/api-reference/s3client/index.html
+++ b/stable/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       
         <link rel="prev" href="../azblobpath/">

--- a/stable/api-reference/s3path/index.html
+++ b/stable/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       
         <link rel="prev" href="../s3client/">

--- a/stable/authentication/index.html
+++ b/stable/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       
         <link rel="prev" href="../why_cloudpathlib/">

--- a/stable/caching/index.html
+++ b/stable/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       
         <link rel="prev" href="../authentication/">

--- a/stable/changelog/index.html
+++ b/stable/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../contributing/">

--- a/stable/contributing/index.html
+++ b/stable/contributing/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/contributing/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/contributing/">
       
       
         <link rel="prev" href="../integrations/">

--- a/stable/index.html
+++ b/stable/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       
       

--- a/stable/integrations/index.html
+++ b/stable/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       
         <link rel="prev" href="../testing_mocked_cloudpathlib/">

--- a/stable/other_client_settings/index.html
+++ b/stable/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       
         <link rel="prev" href="../anypath-polymorphism/">

--- a/stable/script/caching/index.html
+++ b/stable/script/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/script/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/caching/">
       
       
       

--- a/stable/script/testing_mocked_cloudpathlib/index.html
+++ b/stable/script/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/script/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/testing_mocked_cloudpathlib/">
       
       
       

--- a/stable/script/why_cloudpathlib/index.html
+++ b/stable/script/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/script/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/why_cloudpathlib/">
       
       
       

--- a/stable/testing_mocked_cloudpathlib/index.html
+++ b/stable/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       
         <link rel="prev" href="../other_client_settings/">

--- a/stable/why_cloudpathlib/index.html
+++ b/stable/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       
         <link rel="prev" href="..">

--- a/v0.1/api-reference/azblobclient/index.html
+++ b/v0.1/api-reference/azblobclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/azblobpath/index.html
+++ b/v0.1/api-reference/azblobpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/cloudpath/index.html
+++ b/v0.1/api-reference/cloudpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/s3client/index.html
+++ b/v0.1/api-reference/s3client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/s3path/index.html
+++ b/v0.1/api-reference/s3path/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/authentication/index.html
+++ b/v0.1/authentication/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/caching/index.html
+++ b/v0.1/caching/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/changelog/index.html
+++ b/v0.1/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/index.html
+++ b/v0.1/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/why_cloudpathlib/index.html
+++ b/v0.1/why_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.1/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.10/anypath-polymorphism/index.html
+++ b/v0.10/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/anypath/index.html
+++ b/v0.10/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/azblobclient/index.html
+++ b/v0.10/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/azblobpath/index.html
+++ b/v0.10/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/client/index.html
+++ b/v0.10/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/cloudpath/index.html
+++ b/v0.10/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/exceptions/index.html
+++ b/v0.10/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/gsclient/index.html
+++ b/v0.10/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/gspath/index.html
+++ b/v0.10/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/local/index.html
+++ b/v0.10/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/s3client/index.html
+++ b/v0.10/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/api-reference/s3path/index.html
+++ b/v0.10/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/authentication/index.html
+++ b/v0.10/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/caching/index.html
+++ b/v0.10/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/changelog/index.html
+++ b/v0.10/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/index.html
+++ b/v0.10/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/integrations/index.html
+++ b/v0.10/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/other_client_settings/index.html
+++ b/v0.10/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/testing_mocked_cloudpathlib/index.html
+++ b/v0.10/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.10/why_cloudpathlib/index.html
+++ b/v0.10/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.10/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.1, mkdocs-material-8.4.0">

--- a/v0.11/anypath-polymorphism/index.html
+++ b/v0.11/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/anypath/index.html
+++ b/v0.11/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/azblobclient/index.html
+++ b/v0.11/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/azblobpath/index.html
+++ b/v0.11/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/client/index.html
+++ b/v0.11/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/cloudpath/index.html
+++ b/v0.11/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/exceptions/index.html
+++ b/v0.11/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/gsclient/index.html
+++ b/v0.11/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/gspath/index.html
+++ b/v0.11/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/local/index.html
+++ b/v0.11/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/s3client/index.html
+++ b/v0.11/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/api-reference/s3path/index.html
+++ b/v0.11/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/authentication/index.html
+++ b/v0.11/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/caching/index.html
+++ b/v0.11/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/changelog/index.html
+++ b/v0.11/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/index.html
+++ b/v0.11/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/integrations/index.html
+++ b/v0.11/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/other_client_settings/index.html
+++ b/v0.11/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/testing_mocked_cloudpathlib/index.html
+++ b/v0.11/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.11/why_cloudpathlib/index.html
+++ b/v0.11/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.11/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/anypath-polymorphism/index.html
+++ b/v0.12/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/anypath/index.html
+++ b/v0.12/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/azblobclient/index.html
+++ b/v0.12/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/azblobpath/index.html
+++ b/v0.12/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/client/index.html
+++ b/v0.12/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/cloudpath/index.html
+++ b/v0.12/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/exceptions/index.html
+++ b/v0.12/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/gsclient/index.html
+++ b/v0.12/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/gspath/index.html
+++ b/v0.12/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/local/index.html
+++ b/v0.12/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/s3client/index.html
+++ b/v0.12/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/api-reference/s3path/index.html
+++ b/v0.12/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/authentication/index.html
+++ b/v0.12/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/caching/index.html
+++ b/v0.12/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/changelog/index.html
+++ b/v0.12/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/index.html
+++ b/v0.12/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/integrations/index.html
+++ b/v0.12/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/other_client_settings/index.html
+++ b/v0.12/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/testing_mocked_cloudpathlib/index.html
+++ b/v0.12/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.12/why_cloudpathlib/index.html
+++ b/v0.12/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.12/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/anypath-polymorphism/index.html
+++ b/v0.13/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/anypath/index.html
+++ b/v0.13/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/azblobclient/index.html
+++ b/v0.13/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/azblobpath/index.html
+++ b/v0.13/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/client/index.html
+++ b/v0.13/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/cloudpath/index.html
+++ b/v0.13/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/enums/index.html
+++ b/v0.13/api-reference/enums/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/enums/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/enums/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/exceptions/index.html
+++ b/v0.13/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/gsclient/index.html
+++ b/v0.13/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/gspath/index.html
+++ b/v0.13/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/local/index.html
+++ b/v0.13/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/s3client/index.html
+++ b/v0.13/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/api-reference/s3path/index.html
+++ b/v0.13/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/authentication/index.html
+++ b/v0.13/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/caching/index.html
+++ b/v0.13/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/changelog/index.html
+++ b/v0.13/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/index.html
+++ b/v0.13/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/integrations/index.html
+++ b/v0.13/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/other_client_settings/index.html
+++ b/v0.13/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/script/caching/index.html
+++ b/v0.13/script/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/script/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/caching/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/script/testing_mocked_cloudpathlib/index.html
+++ b/v0.13/script/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/script/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/script/why_cloudpathlib/index.html
+++ b/v0.13/script/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/script/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/why_cloudpathlib/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/testing_mocked_cloudpathlib/index.html
+++ b/v0.13/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.13/why_cloudpathlib/index.html
+++ b/v0.13/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.13/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.5.10">

--- a/v0.14/anypath-polymorphism/index.html
+++ b/v0.14/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       
         <link rel="prev" href="../caching/">

--- a/v0.14/api-reference/anypath/index.html
+++ b/v0.14/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       
         <link rel="prev" href="../cloudpath/">

--- a/v0.14/api-reference/azblobclient/index.html
+++ b/v0.14/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       
         <link rel="prev" href="../anypath/">

--- a/v0.14/api-reference/azblobpath/index.html
+++ b/v0.14/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       
         <link rel="prev" href="../azblobclient/">

--- a/v0.14/api-reference/client/index.html
+++ b/v0.14/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       
         <link rel="prev" href="../gspath/">

--- a/v0.14/api-reference/cloudpath/index.html
+++ b/v0.14/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       
         <link rel="prev" href="../../changelog/">

--- a/v0.14/api-reference/enums/index.html
+++ b/v0.14/api-reference/enums/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/enums/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/enums/">
       
       
         <link rel="prev" href="../client/">

--- a/v0.14/api-reference/exceptions/index.html
+++ b/v0.14/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       
         <link rel="prev" href="../enums/">

--- a/v0.14/api-reference/gsclient/index.html
+++ b/v0.14/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       
         <link rel="prev" href="../s3path/">

--- a/v0.14/api-reference/gspath/index.html
+++ b/v0.14/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       
         <link rel="prev" href="../gsclient/">

--- a/v0.14/api-reference/local/index.html
+++ b/v0.14/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       
         <link rel="prev" href="../exceptions/">

--- a/v0.14/api-reference/s3client/index.html
+++ b/v0.14/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       
         <link rel="prev" href="../azblobpath/">

--- a/v0.14/api-reference/s3path/index.html
+++ b/v0.14/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       
         <link rel="prev" href="../s3client/">

--- a/v0.14/authentication/index.html
+++ b/v0.14/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       
         <link rel="prev" href="../why_cloudpathlib/">

--- a/v0.14/caching/index.html
+++ b/v0.14/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       
         <link rel="prev" href="../authentication/">

--- a/v0.14/changelog/index.html
+++ b/v0.14/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../integrations/">

--- a/v0.14/index.html
+++ b/v0.14/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       
       

--- a/v0.14/integrations/index.html
+++ b/v0.14/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       
         <link rel="prev" href="../testing_mocked_cloudpathlib/">

--- a/v0.14/other_client_settings/index.html
+++ b/v0.14/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       
         <link rel="prev" href="../anypath-polymorphism/">

--- a/v0.14/script/caching/index.html
+++ b/v0.14/script/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/script/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/caching/">
       
       
       

--- a/v0.14/script/testing_mocked_cloudpathlib/index.html
+++ b/v0.14/script/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/script/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/testing_mocked_cloudpathlib/">
       
       
       

--- a/v0.14/script/why_cloudpathlib/index.html
+++ b/v0.14/script/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/script/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/why_cloudpathlib/">
       
       
       

--- a/v0.14/testing_mocked_cloudpathlib/index.html
+++ b/v0.14/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       
         <link rel="prev" href="../other_client_settings/">

--- a/v0.14/why_cloudpathlib/index.html
+++ b/v0.14/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.14/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       
         <link rel="prev" href="..">

--- a/v0.15/anypath-polymorphism/index.html
+++ b/v0.15/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       
         <link rel="prev" href="../caching/">

--- a/v0.15/api-reference/anypath/index.html
+++ b/v0.15/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       
         <link rel="prev" href="../cloudpath/">

--- a/v0.15/api-reference/azblobclient/index.html
+++ b/v0.15/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       
         <link rel="prev" href="../anypath/">

--- a/v0.15/api-reference/azblobpath/index.html
+++ b/v0.15/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       
         <link rel="prev" href="../azblobclient/">

--- a/v0.15/api-reference/client/index.html
+++ b/v0.15/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       
         <link rel="prev" href="../gspath/">

--- a/v0.15/api-reference/cloudpath/index.html
+++ b/v0.15/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       
         <link rel="prev" href="../../changelog/">

--- a/v0.15/api-reference/enums/index.html
+++ b/v0.15/api-reference/enums/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/enums/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/enums/">
       
       
         <link rel="prev" href="../client/">

--- a/v0.15/api-reference/exceptions/index.html
+++ b/v0.15/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       
         <link rel="prev" href="../enums/">

--- a/v0.15/api-reference/gsclient/index.html
+++ b/v0.15/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       
         <link rel="prev" href="../s3path/">

--- a/v0.15/api-reference/gspath/index.html
+++ b/v0.15/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       
         <link rel="prev" href="../gsclient/">

--- a/v0.15/api-reference/local/index.html
+++ b/v0.15/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       
         <link rel="prev" href="../exceptions/">

--- a/v0.15/api-reference/s3client/index.html
+++ b/v0.15/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       
         <link rel="prev" href="../azblobpath/">

--- a/v0.15/api-reference/s3path/index.html
+++ b/v0.15/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       
         <link rel="prev" href="../s3client/">

--- a/v0.15/authentication/index.html
+++ b/v0.15/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       
         <link rel="prev" href="../why_cloudpathlib/">

--- a/v0.15/caching/index.html
+++ b/v0.15/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       
         <link rel="prev" href="../authentication/">

--- a/v0.15/changelog/index.html
+++ b/v0.15/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../integrations/">

--- a/v0.15/index.html
+++ b/v0.15/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       
       

--- a/v0.15/integrations/index.html
+++ b/v0.15/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       
         <link rel="prev" href="../testing_mocked_cloudpathlib/">

--- a/v0.15/other_client_settings/index.html
+++ b/v0.15/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       
         <link rel="prev" href="../anypath-polymorphism/">

--- a/v0.15/script/caching/index.html
+++ b/v0.15/script/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/script/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/caching/">
       
       
       

--- a/v0.15/script/testing_mocked_cloudpathlib/index.html
+++ b/v0.15/script/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/script/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/testing_mocked_cloudpathlib/">
       
       
       

--- a/v0.15/script/why_cloudpathlib/index.html
+++ b/v0.15/script/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/script/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/why_cloudpathlib/">
       
       
       

--- a/v0.15/testing_mocked_cloudpathlib/index.html
+++ b/v0.15/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       
         <link rel="prev" href="../other_client_settings/">

--- a/v0.15/why_cloudpathlib/index.html
+++ b/v0.15/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.15/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       
         <link rel="prev" href="..">

--- a/v0.16/anypath-polymorphism/index.html
+++ b/v0.16/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       
         <link rel="prev" href="../caching/">

--- a/v0.16/api-reference/anypath/index.html
+++ b/v0.16/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       
         <link rel="prev" href="../cloudpath/">

--- a/v0.16/api-reference/azblobclient/index.html
+++ b/v0.16/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       
         <link rel="prev" href="../anypath/">

--- a/v0.16/api-reference/azblobpath/index.html
+++ b/v0.16/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       
         <link rel="prev" href="../azblobclient/">

--- a/v0.16/api-reference/client/index.html
+++ b/v0.16/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       
         <link rel="prev" href="../gspath/">

--- a/v0.16/api-reference/cloudpath/index.html
+++ b/v0.16/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       
         <link rel="prev" href="../../changelog/">

--- a/v0.16/api-reference/enums/index.html
+++ b/v0.16/api-reference/enums/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/enums/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/enums/">
       
       
         <link rel="prev" href="../client/">

--- a/v0.16/api-reference/exceptions/index.html
+++ b/v0.16/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       
         <link rel="prev" href="../enums/">

--- a/v0.16/api-reference/gsclient/index.html
+++ b/v0.16/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       
         <link rel="prev" href="../s3path/">

--- a/v0.16/api-reference/gspath/index.html
+++ b/v0.16/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       
         <link rel="prev" href="../gsclient/">

--- a/v0.16/api-reference/local/index.html
+++ b/v0.16/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       
         <link rel="prev" href="../exceptions/">

--- a/v0.16/api-reference/s3client/index.html
+++ b/v0.16/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       
         <link rel="prev" href="../azblobpath/">

--- a/v0.16/api-reference/s3path/index.html
+++ b/v0.16/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       
         <link rel="prev" href="../s3client/">

--- a/v0.16/authentication/index.html
+++ b/v0.16/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       
         <link rel="prev" href="../why_cloudpathlib/">

--- a/v0.16/caching/index.html
+++ b/v0.16/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       
         <link rel="prev" href="../authentication/">

--- a/v0.16/changelog/index.html
+++ b/v0.16/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../contributing/">

--- a/v0.16/contributing/index.html
+++ b/v0.16/contributing/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/contributing/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/contributing/">
       
       
         <link rel="prev" href="../integrations/">

--- a/v0.16/index.html
+++ b/v0.16/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       
       

--- a/v0.16/integrations/index.html
+++ b/v0.16/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       
         <link rel="prev" href="../testing_mocked_cloudpathlib/">

--- a/v0.16/other_client_settings/index.html
+++ b/v0.16/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       
         <link rel="prev" href="../anypath-polymorphism/">

--- a/v0.16/script/caching/index.html
+++ b/v0.16/script/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/script/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/caching/">
       
       
       

--- a/v0.16/script/testing_mocked_cloudpathlib/index.html
+++ b/v0.16/script/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/script/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/testing_mocked_cloudpathlib/">
       
       
       

--- a/v0.16/script/why_cloudpathlib/index.html
+++ b/v0.16/script/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/script/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/why_cloudpathlib/">
       
       
       

--- a/v0.16/testing_mocked_cloudpathlib/index.html
+++ b/v0.16/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       
         <link rel="prev" href="../other_client_settings/">

--- a/v0.16/why_cloudpathlib/index.html
+++ b/v0.16/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.16/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       
         <link rel="prev" href="..">

--- a/v0.17/anypath-polymorphism/index.html
+++ b/v0.17/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       
         <link rel="prev" href="../caching/">

--- a/v0.17/api-reference/anypath/index.html
+++ b/v0.17/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       
         <link rel="prev" href="../cloudpath/">

--- a/v0.17/api-reference/azblobclient/index.html
+++ b/v0.17/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       
         <link rel="prev" href="../anypath/">

--- a/v0.17/api-reference/azblobpath/index.html
+++ b/v0.17/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       
         <link rel="prev" href="../azblobclient/">

--- a/v0.17/api-reference/client/index.html
+++ b/v0.17/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       
         <link rel="prev" href="../gspath/">

--- a/v0.17/api-reference/cloudpath/index.html
+++ b/v0.17/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       
         <link rel="prev" href="../../changelog/">

--- a/v0.17/api-reference/enums/index.html
+++ b/v0.17/api-reference/enums/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/enums/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/enums/">
       
       
         <link rel="prev" href="../client/">

--- a/v0.17/api-reference/exceptions/index.html
+++ b/v0.17/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       
         <link rel="prev" href="../enums/">

--- a/v0.17/api-reference/gsclient/index.html
+++ b/v0.17/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       
         <link rel="prev" href="../s3path/">

--- a/v0.17/api-reference/gspath/index.html
+++ b/v0.17/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       
         <link rel="prev" href="../gsclient/">

--- a/v0.17/api-reference/local/index.html
+++ b/v0.17/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       
         <link rel="prev" href="../exceptions/">

--- a/v0.17/api-reference/s3client/index.html
+++ b/v0.17/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       
         <link rel="prev" href="../azblobpath/">

--- a/v0.17/api-reference/s3path/index.html
+++ b/v0.17/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       
         <link rel="prev" href="../s3client/">

--- a/v0.17/authentication/index.html
+++ b/v0.17/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       
         <link rel="prev" href="../why_cloudpathlib/">

--- a/v0.17/caching/index.html
+++ b/v0.17/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       
         <link rel="prev" href="../authentication/">

--- a/v0.17/changelog/index.html
+++ b/v0.17/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../contributing/">

--- a/v0.17/contributing/index.html
+++ b/v0.17/contributing/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/contributing/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/contributing/">
       
       
         <link rel="prev" href="../integrations/">

--- a/v0.17/index.html
+++ b/v0.17/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       
       

--- a/v0.17/integrations/index.html
+++ b/v0.17/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       
         <link rel="prev" href="../testing_mocked_cloudpathlib/">

--- a/v0.17/other_client_settings/index.html
+++ b/v0.17/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       
         <link rel="prev" href="../anypath-polymorphism/">

--- a/v0.17/script/caching/index.html
+++ b/v0.17/script/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/script/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/caching/">
       
       
       

--- a/v0.17/script/testing_mocked_cloudpathlib/index.html
+++ b/v0.17/script/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/script/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/testing_mocked_cloudpathlib/">
       
       
       

--- a/v0.17/script/why_cloudpathlib/index.html
+++ b/v0.17/script/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/script/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/script/why_cloudpathlib/">
       
       
       

--- a/v0.17/testing_mocked_cloudpathlib/index.html
+++ b/v0.17/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       
         <link rel="prev" href="../other_client_settings/">

--- a/v0.17/why_cloudpathlib/index.html
+++ b/v0.17/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.17/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       
         <link rel="prev" href="..">

--- a/v0.2/api-reference/azblobclient/index.html
+++ b/v0.2/api-reference/azblobclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/azblobpath/index.html
+++ b/v0.2/api-reference/azblobpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/cloudpath/index.html
+++ b/v0.2/api-reference/cloudpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/gsclient/index.html
+++ b/v0.2/api-reference/gsclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/gspath/index.html
+++ b/v0.2/api-reference/gspath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/s3client/index.html
+++ b/v0.2/api-reference/s3client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/s3path/index.html
+++ b/v0.2/api-reference/s3path/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/authentication/index.html
+++ b/v0.2/authentication/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/caching/index.html
+++ b/v0.2/caching/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/changelog/index.html
+++ b/v0.2/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/index.html
+++ b/v0.2/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/why_cloudpathlib/index.html
+++ b/v0.2/why_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.2/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/azblobclient/index.html
+++ b/v0.3/api-reference/azblobclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/azblobpath/index.html
+++ b/v0.3/api-reference/azblobpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/cloudpath/index.html
+++ b/v0.3/api-reference/cloudpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/gsclient/index.html
+++ b/v0.3/api-reference/gsclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/gspath/index.html
+++ b/v0.3/api-reference/gspath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/local/index.html
+++ b/v0.3/api-reference/local/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/s3client/index.html
+++ b/v0.3/api-reference/s3client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/s3path/index.html
+++ b/v0.3/api-reference/s3path/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/authentication/index.html
+++ b/v0.3/authentication/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/caching/index.html
+++ b/v0.3/caching/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/changelog/index.html
+++ b/v0.3/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/index.html
+++ b/v0.3/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/testing_mocked_cloudpathlib/index.html
+++ b/v0.3/testing_mocked_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/why_cloudpathlib/index.html
+++ b/v0.3/why_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.3/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/anypath-polymorphism/index.html
+++ b/v0.4/anypath-polymorphism/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/anypath/index.html
+++ b/v0.4/api-reference/anypath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/azblobclient/index.html
+++ b/v0.4/api-reference/azblobclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/azblobpath/index.html
+++ b/v0.4/api-reference/azblobpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/client/index.html
+++ b/v0.4/api-reference/client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/cloudpath/index.html
+++ b/v0.4/api-reference/cloudpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/exceptions/index.html
+++ b/v0.4/api-reference/exceptions/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/gsclient/index.html
+++ b/v0.4/api-reference/gsclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/gspath/index.html
+++ b/v0.4/api-reference/gspath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/local/index.html
+++ b/v0.4/api-reference/local/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/s3client/index.html
+++ b/v0.4/api-reference/s3client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/s3path/index.html
+++ b/v0.4/api-reference/s3path/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/authentication/index.html
+++ b/v0.4/authentication/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/caching/index.html
+++ b/v0.4/caching/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/changelog/index.html
+++ b/v0.4/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/index.html
+++ b/v0.4/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/integrations/index.html
+++ b/v0.4/integrations/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/testing_mocked_cloudpathlib/index.html
+++ b/v0.4/testing_mocked_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/why_cloudpathlib/index.html
+++ b/v0.4/why_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.4/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/anypath-polymorphism/index.html
+++ b/v0.5/anypath-polymorphism/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/anypath/index.html
+++ b/v0.5/api-reference/anypath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/azblobclient/index.html
+++ b/v0.5/api-reference/azblobclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/azblobpath/index.html
+++ b/v0.5/api-reference/azblobpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/client/index.html
+++ b/v0.5/api-reference/client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/cloudpath/index.html
+++ b/v0.5/api-reference/cloudpath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/exceptions/index.html
+++ b/v0.5/api-reference/exceptions/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/gsclient/index.html
+++ b/v0.5/api-reference/gsclient/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/gspath/index.html
+++ b/v0.5/api-reference/gspath/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/local/index.html
+++ b/v0.5/api-reference/local/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/s3client/index.html
+++ b/v0.5/api-reference/s3client/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/api-reference/s3path/index.html
+++ b/v0.5/api-reference/s3path/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/authentication/index.html
+++ b/v0.5/authentication/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/caching/index.html
+++ b/v0.5/caching/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/changelog/index.html
+++ b/v0.5/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/index.html
+++ b/v0.5/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/integrations/index.html
+++ b/v0.5/integrations/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/testing_mocked_cloudpathlib/index.html
+++ b/v0.5/testing_mocked_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.5/why_cloudpathlib/index.html
+++ b/v0.5/why_cloudpathlib/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.5/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.6/anypath-polymorphism/index.html
+++ b/v0.6/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/anypath/index.html
+++ b/v0.6/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/azblobclient/index.html
+++ b/v0.6/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/azblobpath/index.html
+++ b/v0.6/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/client/index.html
+++ b/v0.6/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/cloudpath/index.html
+++ b/v0.6/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/exceptions/index.html
+++ b/v0.6/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/gsclient/index.html
+++ b/v0.6/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/gspath/index.html
+++ b/v0.6/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/local/index.html
+++ b/v0.6/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/s3client/index.html
+++ b/v0.6/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/api-reference/s3path/index.html
+++ b/v0.6/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/authentication/index.html
+++ b/v0.6/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/caching/index.html
+++ b/v0.6/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/changelog/index.html
+++ b/v0.6/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/index.html
+++ b/v0.6/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/integrations/index.html
+++ b/v0.6/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/testing_mocked_cloudpathlib/index.html
+++ b/v0.6/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.6/why_cloudpathlib/index.html
+++ b/v0.6/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.6/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.8">

--- a/v0.7/anypath-polymorphism/index.html
+++ b/v0.7/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/anypath/index.html
+++ b/v0.7/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/azblobclient/index.html
+++ b/v0.7/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/azblobpath/index.html
+++ b/v0.7/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/client/index.html
+++ b/v0.7/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/cloudpath/index.html
+++ b/v0.7/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/exceptions/index.html
+++ b/v0.7/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/gsclient/index.html
+++ b/v0.7/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/gspath/index.html
+++ b/v0.7/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/local/index.html
+++ b/v0.7/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/s3client/index.html
+++ b/v0.7/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/api-reference/s3path/index.html
+++ b/v0.7/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/authentication/index.html
+++ b/v0.7/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/caching/index.html
+++ b/v0.7/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/changelog/index.html
+++ b/v0.7/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/index.html
+++ b/v0.7/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/integrations/index.html
+++ b/v0.7/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/testing_mocked_cloudpathlib/index.html
+++ b/v0.7/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.7/why_cloudpathlib/index.html
+++ b/v0.7/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.7/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.8">

--- a/v0.8/anypath-polymorphism/index.html
+++ b/v0.8/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/anypath/index.html
+++ b/v0.8/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/azblobclient/index.html
+++ b/v0.8/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/azblobpath/index.html
+++ b/v0.8/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/client/index.html
+++ b/v0.8/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/cloudpath/index.html
+++ b/v0.8/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/exceptions/index.html
+++ b/v0.8/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/gsclient/index.html
+++ b/v0.8/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/gspath/index.html
+++ b/v0.8/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/local/index.html
+++ b/v0.8/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/s3client/index.html
+++ b/v0.8/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/api-reference/s3path/index.html
+++ b/v0.8/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/authentication/index.html
+++ b/v0.8/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/caching/index.html
+++ b/v0.8/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/changelog/index.html
+++ b/v0.8/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/index.html
+++ b/v0.8/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/integrations/index.html
+++ b/v0.8/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/other_client_settings/index.html
+++ b/v0.8/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/testing_mocked_cloudpathlib/index.html
+++ b/v0.8/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.8/why_cloudpathlib/index.html
+++ b/v0.8/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.8/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.15">

--- a/v0.9/anypath-polymorphism/index.html
+++ b/v0.9/anypath-polymorphism/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/anypath-polymorphism/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/anypath-polymorphism/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/anypath/index.html
+++ b/v0.9/api-reference/anypath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/anypath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/anypath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/azblobclient/index.html
+++ b/v0.9/api-reference/azblobclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/azblobclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/azblobpath/index.html
+++ b/v0.9/api-reference/azblobpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/azblobpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/azblobpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/client/index.html
+++ b/v0.9/api-reference/client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/cloudpath/index.html
+++ b/v0.9/api-reference/cloudpath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/cloudpath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/cloudpath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/exceptions/index.html
+++ b/v0.9/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/exceptions/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/gsclient/index.html
+++ b/v0.9/api-reference/gsclient/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/gsclient/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gsclient/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/gspath/index.html
+++ b/v0.9/api-reference/gspath/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/gspath/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/gspath/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/local/index.html
+++ b/v0.9/api-reference/local/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/local/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/local/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/s3client/index.html
+++ b/v0.9/api-reference/s3client/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/s3client/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3client/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/api-reference/s3path/index.html
+++ b/v0.9/api-reference/s3path/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/api-reference/s3path/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/api-reference/s3path/">
       
       <link rel="icon" href="../../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/authentication/index.html
+++ b/v0.9/authentication/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/authentication/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/authentication/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/caching/index.html
+++ b/v0.9/caching/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/caching/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/caching/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/changelog/index.html
+++ b/v0.9/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/changelog/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/index.html
+++ b/v0.9/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/">
       
       <link rel="icon" href="favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/integrations/index.html
+++ b/v0.9/integrations/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/integrations/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/integrations/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/other_client_settings/index.html
+++ b/v0.9/other_client_settings/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/other_client_settings/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/other_client_settings/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/testing_mocked_cloudpathlib/index.html
+++ b/v0.9/testing_mocked_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/testing_mocked_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">

--- a/v0.9/why_cloudpathlib/index.html
+++ b/v0.9/why_cloudpathlib/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://cloudpathlib.drivendata.org/v0.9/why_cloudpathlib/">
+        <link rel="canonical" href="https://cloudpathlib.drivendata.org/stable/why_cloudpathlib/">
       
       <link rel="icon" href="../favicon.svg">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.3.0">


### PR DESCRIPTION
Updates canonical links to point to the `stable` versions of the docs.

After merging, we'll need to run any CI that deploys docs to push these to Netlify. 

Closes #397 