### PR TITLE
Updates to release v.0.18.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,12 @@
 # cloudpathlib Changelog
 
-## UNRELEASED
+## 0.18.0 (2024-02-25)
 - Implement sliced downloads in GSClient. (Issue [#387](https://github.com/drivendataorg/cloudpathlib/issues/387), PR [#389](https://github.com/drivendataorg/cloudpathlib/pull/389))
 - Implement `as_url` with presigned parameter for all backends. (Issue [#235](https://github.com/drivendataorg/cloudpathlib/issues/235), PR [#236](https://github.com/drivendataorg/cloudpathlib/pull/236))
 - Stream to and from Azure Blob Storage. (PR [#403](https://github.com/drivendataorg/cloudpathlib/pull/403))
 - Implement `file:` URI scheme support for `AnyPath`. (Issue [#401](https://github.com/drivendataorg/cloudpathlib/issues/401), PR [#404](https://github.com/drivendataorg/cloudpathlib/pull/404))
+
+**Note: This is the last planned Python 3.7 compatible release version.**
 
 ## 0.17.0 (2023-12-21)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cloudpathlib"
-version = "0.17.0"
+version = "0.18.0"
 description = "pathlib-style classes for cloud storage services."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }]


### PR DESCRIPTION
Version, changes, etc.

Note: Planning to have this as the last Python 3.7 release and follow it with a PR to drop 3.7.