### PR TITLE
Version floor for google-cloud-storage

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## v0.18.1 (2024-02-26)
 
-- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408)) 
+- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #409)[https://github.com/drivendataorg/cloudpathlib/pull/409]) 
 
 **Note: This is the last planned Python 3.7 compatible release version.**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 - Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #409)[https://github.com/drivendataorg/cloudpathlib/pull/409]) 
 
+Includes all changes from v0.18.0.
+
 **Note: This is the last planned Python 3.7 compatible release version.**
 
 ## 0.18.0 (2024-02-25) (Yanked)
@@ -12,6 +14,8 @@
 - Implement `as_url` with presigned parameter for all backends. (Issue [#235](https://github.com/drivendataorg/cloudpathlib/issues/235), PR [#236](https://github.com/drivendataorg/cloudpathlib/pull/236))
 - Stream to and from Azure Blob Storage. (PR [#403](https://github.com/drivendataorg/cloudpathlib/pull/403))
 - Implement `file:` URI scheme support for `AnyPath`. (Issue [#401](https://github.com/drivendataorg/cloudpathlib/issues/401), PR [#404](https://github.com/drivendataorg/cloudpathlib/pull/404))
+
+**Note: This version was [yanked](https://pypi.org/help/#yanked) due to a missing version floor on the google-cloud-storage dependency that can cause an import error.**
 
 ## 0.17.0 (2023-12-21)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,17 @@
 # cloudpathlib Changelog
 
-## 0.18.0 (2024-02-25)
+## v0.18.1 (2024-02-26)
+
+- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408)) 
+
+**Note: This is the last planned Python 3.7 compatible release version.**
+
+## 0.18.0 (2024-02-25) (Yanked)
+
 - Implement sliced downloads in GSClient. (Issue [#387](https://github.com/drivendataorg/cloudpathlib/issues/387), PR [#389](https://github.com/drivendataorg/cloudpathlib/pull/389))
 - Implement `as_url` with presigned parameter for all backends. (Issue [#235](https://github.com/drivendataorg/cloudpathlib/issues/235), PR [#236](https://github.com/drivendataorg/cloudpathlib/pull/236))
 - Stream to and from Azure Blob Storage. (PR [#403](https://github.com/drivendataorg/cloudpathlib/pull/403))
 - Implement `file:` URI scheme support for `AnyPath`. (Issue [#401](https://github.com/drivendataorg/cloudpathlib/issues/401), PR [#404](https://github.com/drivendataorg/cloudpathlib/pull/404))
-
-**Note: This is the last planned Python 3.7 compatible release version.**
 
 ## 0.17.0 (2023-12-21)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cloudpathlib"
-version = "0.18.0"
+version = "0.18.1"
 description = "pathlib-style classes for cloud storage services."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }]
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 azure = ["azure-storage-blob>=12"]
-gs = ["google-cloud-storage"]
+gs = ["google-cloud-storage>=2.7.0"]
 s3 = ["boto3"]
 all = ["cloudpathlib[azure]", "cloudpathlib[gs]", "cloudpathlib[s3]"]
 


### PR DESCRIPTION
Fixes an import error when cloudpathlib is installed alongside an incompatible version of google-cloud-storage.

I think the plan here should be:

- Merge this into branch `hotfix/v0.18.1-google-cloud-storage` which we tag and maintain as the source for a v0.18.1 release.
- Yank v0.18.0, so that resolvers will not install v0.18.0 alongside `google-cloud-storage<2.7.0`

Closes #408. 