### PR TITLE
Support versions of GCS without transfer_manager

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,21 @@
 # cloudpathlib Changelog
 
-## 0.18.0 (2024-02-25)
+## v0.18.1 (2024-02-26)
+
+- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #409)[https://github.com/drivendataorg/cloudpathlib/pull/409]) 
+
+Includes all changes from v0.18.0.
+
+**Note: This is the last planned Python 3.7 compatible release version.**
+
+## 0.18.0 (2024-02-25) (Yanked)
+
 - Implement sliced downloads in GSClient. (Issue [#387](https://github.com/drivendataorg/cloudpathlib/issues/387), PR [#389](https://github.com/drivendataorg/cloudpathlib/pull/389))
 - Implement `as_url` with presigned parameter for all backends. (Issue [#235](https://github.com/drivendataorg/cloudpathlib/issues/235), PR [#236](https://github.com/drivendataorg/cloudpathlib/pull/236))
 - Stream to and from Azure Blob Storage. (PR [#403](https://github.com/drivendataorg/cloudpathlib/pull/403))
 - Implement `file:` URI scheme support for `AnyPath`. (Issue [#401](https://github.com/drivendataorg/cloudpathlib/issues/401), PR [#404](https://github.com/drivendataorg/cloudpathlib/pull/404))
 
-**Note: This is the last planned Python 3.7 compatible release version.**
+**Note: This version was [yanked](https://pypi.org/help/#yanked) due to a missing version floor on the google-cloud-storage dependency that can cause an import error.**
 
 ## 0.17.0 (2023-12-21)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## v0.18.1 (2024-02-26)
 
-- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #410)[https://github.com/drivendataorg/cloudpathlib/pull/410]) 
+- Fixed import error due to incompatible `google-cloud-storage` by not using `transfer_manager` if it is not available. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #410)[https://github.com/drivendataorg/cloudpathlib/pull/410]) 
 
 Includes all changes from v0.18.0.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## v0.18.1 (2024-02-26)
 
-- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #409)[https://github.com/drivendataorg/cloudpathlib/pull/409]) 
+- Fixed import error due to incompatible google-cloud-strage by adding a version floor. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), (PR #410)[https://github.com/drivendataorg/cloudpathlib/pull/410]) 
 
 Includes all changes from v0.18.0.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,7 +15,7 @@ Includes all changes from v0.18.0.
 - Stream to and from Azure Blob Storage. (PR [#403](https://github.com/drivendataorg/cloudpathlib/pull/403))
 - Implement `file:` URI scheme support for `AnyPath`. (Issue [#401](https://github.com/drivendataorg/cloudpathlib/issues/401), PR [#404](https://github.com/drivendataorg/cloudpathlib/pull/404))
 
-**Note: This version was [yanked](https://pypi.org/help/#yanked) due to a missing version floor on the google-cloud-storage dependency that can cause an import error.**
+**Note: This version was [yanked](https://pypi.org/help/#yanked) due to incompatibility with google-cloud-storage <2.7.0 that causes an import error.**
 
 ## 0.17.0 (2023-12-21)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cloudpathlib"
-version = "0.18.0"
+version = "0.18.1"
 description = "pathlib-style classes for cloud storage services."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }]


### PR DESCRIPTION
Add support for `google-cloud-storage<2.7.0` per discussion in #408 and #409.

- Manually confirmed the test suite passes with `google-cloud-storage==2.6.0` (and fails without the fix)
- Warns if user passes `transfer_manager` kwargs that can't be used
- Adds changelog notes
- Bumps version