### PR TITLE
Defend from AttributeErrors in CloudPath.__del__

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
- - Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
+- Fix `CloudPath` cleanup via `CloudPath.__del__` when `Client` encounters an exception during initialization and does not create a `file_cache_mode` attribute. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), thanks to [@bryanwweber](https://github.com/bryanwweber)) 
+- Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
 
 ## v0.18.1 (2024-02-26)
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -246,7 +246,7 @@ class CloudPath(metaclass=CloudPathMeta):
 
         # ensure file removed from cache when cloudpath object deleted
         client = getattr(self, "client", object)
-        if getattr(client, "file_cache_mode", None) == FileCacheMode.close_file:
+        if getattr(client, "file_cache_mode", None) == FileCacheMode.cloudpath_object:
             self.clear_cache()
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -245,7 +245,7 @@ class CloudPath(metaclass=CloudPathMeta):
             self._handle.close()
 
         # ensure file removed from cache when cloudpath object deleted
-        client = getattr(self, "client", object)
+        client = getattr(self, "client", None)
         if getattr(client, "file_cache_mode", None) == FileCacheMode.cloudpath_object:
             self.clear_cache()
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -245,10 +245,8 @@ class CloudPath(metaclass=CloudPathMeta):
             self._handle.close()
 
         # ensure file removed from cache when cloudpath object deleted
-        if (
-            hasattr(self, "client")
-            and self.client.file_cache_mode == FileCacheMode.cloudpath_object
-        ):
+        client = getattr(self, "client", object)
+        if getattr(client, "file_cache_mode", None) == FileCacheMode.close_file:
             self.clear_cache()
 
     def __getstate__(self) -> Dict[str, Any]:


### PR DESCRIPTION
If the CloudPath Client instance is incomplete, it may not have a file_cache_mode attribute. Using getattr defensively prevents the AttributeError from causing __del__ to exit early.

Closes #372 

----------------

Contributor checklist:

 - [X] I have read and understood `CONTRIBUTING.md`
 - [X] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [X] Confirmed PR is rebased onto the latest base
 - [ ] Confirmed failure before change and success after change
 - [X] Linting passes locally
 - [ ] Tests pass locally
 - [X] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.