### PR TITLE
fix: use native `exists()` method in `GSClient`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 - Fix `CloudPath` cleanup via `CloudPath.__del__` when `Client` encounters an exception during initialization and does not create a `file_cache_mode` attribute. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), thanks to [@bryanwweber](https://github.com/bryanwweber)) 
 - Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
+- fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
 
 ## v0.18.1 (2024-02-26)
 

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -14,7 +14,6 @@ try:
     if TYPE_CHECKING:
         from google.auth.credentials import Credentials
 
-    from google.api_core.exceptions import NotFound
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud.storage import Client as StorageClient
 

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -169,7 +169,11 @@ class GSClient(Client):
                 return None
 
     def _exists(self, cloud_path: GSPath) -> bool:
-        return self.client.bucket(cloud_path.bucket).exists()
+        # short-circuit the root-level bucket
+        if not cloud_path.blob:
+            return self.client.bucket(cloud_path.bucket).exists()
+
+        return self._is_file_or_dir(cloud_path) in ["file", "dir"]
 
     def _list_dir(self, cloud_path: GSPath, recursive=False) -> Iterable[Tuple[GSPath, bool]]:
         # shortcut if listing all available buckets

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -169,15 +169,7 @@ class GSClient(Client):
                 return None
 
     def _exists(self, cloud_path: GSPath) -> bool:
-        # short-circuit the root-level bucket
-        if not cloud_path.blob:
-            try:
-                next(self.client.bucket(cloud_path.bucket).list_blobs())
-                return True
-            except NotFound:
-                return False
-
-        return self._is_file_or_dir(cloud_path) in ["file", "dir"]
+        return self.client.bucket(cloud_path.bucket).exists()
 
     def _list_dir(self, cloud_path: GSPath, recursive=False) -> Iterable[Tuple[GSPath, bool]]:
         # shortcut if listing all available buckets

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -133,7 +133,7 @@ class MockBucket:
         dst.write_bytes(data)
 
     def exists(self):
-        if self.container_name == DEFAULT_GS_BUCKET_NAME :  # name used by passing tests
+        if self.bucket_name == DEFAULT_GS_BUCKET_NAME:  # name used by passing tests
             return True
         else:
             return False

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -132,6 +132,12 @@ class MockBucket:
         dst.parent.mkdir(exist_ok=True, parents=True)
         dst.write_bytes(data)
 
+    def exists(self):
+        if self.container_name == DEFAULT_GS_BUCKET_NAME :  # name used by passing tests
+            return True
+        else:
+            return False
+
     def get_blob(self, blob):
         if (self.name / blob).is_file():
             return MockBlob(self.name, blob, client=self.client)


### PR DESCRIPTION
SSIA

Closes https://github.com/drivendataorg/cloudpathlib/issues/356

----------------

Contributor checklist:

 - [x] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [x] Confirmed PR is rebased onto the latest base
 - [x] Confirmed failure before change and success after change
 - [ ] Any generic new functionality is replicated across cloud providers if necessary
 - [x] Tested manually against live server backend for at least one provider
 - [ ] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [x] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.