### PR TITLE
fix: use native `exists()` method in `GSClient` (#420)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 - Fix `CloudPath` cleanup via `CloudPath.__del__` when `Client` encounters an exception during initialization and does not create a `file_cache_mode` attribute. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), thanks to [@bryanwweber](https://github.com/bryanwweber)) 
 - Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
+- fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
 
 ## v0.18.1 (2024-02-26)
 

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -14,7 +14,6 @@ try:
     if TYPE_CHECKING:
         from google.auth.credentials import Credentials
 
-    from google.api_core.exceptions import NotFound
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud.storage import Client as StorageClient
 
@@ -171,11 +170,7 @@ class GSClient(Client):
     def _exists(self, cloud_path: GSPath) -> bool:
         # short-circuit the root-level bucket
         if not cloud_path.blob:
-            try:
-                next(self.client.bucket(cloud_path.bucket).list_blobs())
-                return True
-            except NotFound:
-                return False
+            return self.client.bucket(cloud_path.bucket).exists()
 
         return self._is_file_or_dir(cloud_path) in ["file", "dir"]
 

--- a/tests/mock_clients/mock_gs.py
+++ b/tests/mock_clients/mock_gs.py
@@ -132,6 +132,12 @@ class MockBucket:
         dst.parent.mkdir(exist_ok=True, parents=True)
         dst.write_bytes(data)
 
+    def exists(self):
+        if self.bucket_name == DEFAULT_GS_BUCKET_NAME:  # name used by passing tests
+            return True
+        else:
+            return False
+
     def get_blob(self, blob):
         if (self.name / blob).is_file():
             return MockBlob(self.name, blob, client=self.client)


### PR DESCRIPTION
Live server backend tests for #420 

------------

* fix: use native `exists()` method in `GSClient`

* update HISTORY.md

* only short-circuit

* fix lint

* update tests

* lint and tests

Closes https://github.com/drivendataorg/cloudpathlib/issues/356
