### PR TITLE
Instantiate default client lazily

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 - Fix `CloudPath` cleanup via `CloudPath.__del__` when `Client` encounters an exception during initialization and does not create a `file_cache_mode` attribute. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), thanks to [@bryanwweber](https://github.com/bryanwweber)) 
 - Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
 - fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
+- Enhancement: lazy instantiation of default client (PR [#431](https://github.com/drivendataorg/cloudpathlib/issues/431), Issue [#428](https://github.com/drivendataorg/cloudpathlib/issues/428))
 
 ## v0.18.1 (2024-02-26)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 - Fix `CloudPath` cleanup via `CloudPath.__del__` when `Client` encounters an exception during initialization and does not create a `file_cache_mode` attribute. (Issue [#372](https://github.com/drivendataorg/cloudpathlib/issues/372), thanks to [@bryanwweber](https://github.com/bryanwweber)) 
 - Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
 - fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
-- Enhancement: lazy instantiation of default client (PR [#431](https://github.com/drivendataorg/cloudpathlib/issues/431), Issue [#428](https://github.com/drivendataorg/cloudpathlib/issues/428))
+- Enhancement: lazy instantiation of default client (PR [#432](https://github.com/drivendataorg/cloudpathlib/issues/432), Issue [#428](https://github.com/drivendataorg/cloudpathlib/issues/428))
 
 ## v0.18.1 (2024-02-26)
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -217,6 +217,7 @@ class CloudPath(metaclass=CloudPathMeta):
         self._client: Optional["Client"] = None
 
         self.is_valid_cloudpath(cloud_path, raise_on_error=True)
+        self._cloud_meta.validate_completeness()
 
         # versions of the raw string that provide useful methods
         self._str = str(cloud_path)

--- a/tests/test_cloudpath_instantiation.py
+++ b/tests/test_cloudpath_instantiation.py
@@ -59,6 +59,13 @@ def test_instantiation(rig, path):
         assert str(p._path) == expected.split(":/", 1)[-1]
 
 
+def test_default_client_lazy(rig):
+    cp = rig.path_class(rig.cloud_prefix + "testing/file.txt")
+    assert cp._client is None
+    assert cp.client is not None
+    assert cp._client is not None
+
+
 def test_instantiation_errors(rig):
     with pytest.raises(TypeError):
         rig.path_class()


### PR DESCRIPTION
 - Turn `CloudPath.client` into a property
 - Get private `._client` if set
 - If not set, get default client and set that to `._client`
 - Add completeness check for dependencies to `CloudPath.__init__` in addition to client (seems ok since cheap) so those happen upstream

Closes #428
