### PR TITLE
Add exists check in download_to

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 - Drop support for Python 3.7; pin minimal `boto3` version to Python 3.8+ versions. (PR [#407](https://github.com/drivendataorg/cloudpathlib/pull/407))
 - fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
 - Enhancement: lazy instantiation of default client (PR [#432](https://github.com/drivendataorg/cloudpathlib/issues/432), Issue [#428](https://github.com/drivendataorg/cloudpathlib/issues/428))
+- Adds existence check before downloading in `download_to` (Issue [#430](https://github.com/drivendataorg/cloudpathlib/issues/430), PR [#432](https://github.com/drivendataorg/cloudpathlib/pull/432))
 
 ## v0.18.1 (2024-02-26)
 

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -63,6 +63,7 @@ from .exceptions import (
     CloudPathFileExistsError,
     CloudPathIsADirectoryError,
     CloudPathNotADirectoryError,
+    CloudPathNotExistsError,
     CloudPathNotImplementedError,
     DirectoryNotEmptyError,
     IncompleteImplementationError,
@@ -899,6 +900,10 @@ class CloudPath(metaclass=CloudPathMeta):
     # ===========  public cloud methods, not in pathlib ===============
     def download_to(self, destination: Union[str, os.PathLike]) -> Path:
         destination = Path(destination)
+
+        if not self.exists():
+            raise CloudPathNotExistsError(f"Cannot download because path does not exist: {self}")
+
         if self.is_file():
             if destination.is_dir():
                 destination = destination / self.name

--- a/cloudpathlib/exceptions.py
+++ b/cloudpathlib/exceptions.py
@@ -20,6 +20,10 @@ class CloudPathFileExistsError(CloudPathException, FileExistsError):
     pass
 
 
+class CloudPathNotExistsError(CloudPathException):
+    pass
+
+
 class CloudPathIsADirectoryError(CloudPathException, IsADirectoryError):
     pass
 

--- a/tests/test_cloudpath_file_io.py
+++ b/tests/test_cloudpath_file_io.py
@@ -10,6 +10,7 @@ import pytest
 from cloudpathlib import CloudPath
 
 from cloudpathlib.exceptions import (
+    CloudPathNotExistsError,
     CloudPathIsADirectoryError,
     CloudPathNotImplementedError,
     DirectoryNotEmptyError,
@@ -395,6 +396,9 @@ def test_file_read_writes(rig, tmp_path):
         [str(PurePosixPath(p.relative_to(dl_dir))) for p in dl_dir.glob("**/*")]
     )
     assert cloud_rel_paths == dled_rel_paths
+
+    with pytest.raises(CloudPathNotExistsError):
+        (p / "not_exists_file").download_to(dl_file)
 
 
 def test_dispatch_to_local_cache(rig):


### PR DESCRIPTION
Add `.exists` check before `download_to` and raise new `CloudPathNotExistsError` if the path does not exist.

Closes #430
