### PR TITLE
fix(az): improve detection of path types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 - fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
 - Enhancement: lazy instantiation of default client (PR [#432](https://github.com/drivendataorg/cloudpathlib/issues/432), Issue [#428](https://github.com/drivendataorg/cloudpathlib/issues/428))
 - Adds existence check before downloading in `download_to` (Issue [#430](https://github.com/drivendataorg/cloudpathlib/issues/430), PR [#432](https://github.com/drivendataorg/cloudpathlib/pull/432))
+- fix(az): improve detection of path types (Issue [#444](https://github.com/drivendataorg/cloudpathlib/issues/444), PR [#445](https://github.com/drivendataorg/cloudpathlib/pull/445))
 
 ## v0.18.1 (2024-02-26)
 

--- a/tests/mock_clients/mock_azureblob.py
+++ b/tests/mock_clients/mock_azureblob.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 import shutil
@@ -25,7 +25,12 @@ def mocked_client_class_factory(test_dir: str):
             self.tmp_path = Path(self.tmp.name) / "test_case_copy"
             shutil.copytree(TEST_ASSETS, self.tmp_path / test_dir)
 
-            self.metadata_cache = {}
+            self.metadata_cache = defaultdict(
+                lambda: {
+                    "content_type": "application/octet-stream",
+                    "content_md5": "some_md5_hash",
+                }
+            )
 
         @classmethod
         def from_connection_string(cls, *args, **kwargs):
@@ -77,15 +82,22 @@ class MockBlobClient:
 
     def get_blob_properties(self):
         path = self.root / self.key
-        if path.exists() and path.is_file():
+        if path.exists():
+            # replicates the behavior of the Azure Blob API
+            # files always have content_type and content_md5
+            # directories never have content_type and content_md5
+            # https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties?tabs=microsoft-entra-id#response-headers
+            if path.is_file():
+                metadata = self.service_client.metadata_cache[path]
+            else:
+                metadata = {"content_type": None, "content_md5": None}
+
             return BlobProperties(
                 **{
                     "name": self.key,
                     "Last-Modified": datetime.fromtimestamp(path.stat().st_mtime),
                     "ETag": "etag",
-                    "content_type": self.service_client.metadata_cache.get(
-                        self.root / self.key, None
-                    ),
+                    **metadata,
                 }
             )
         else:
@@ -114,9 +126,13 @@ class MockBlobClient:
         path.write_bytes(data.read())
 
         if content_settings is not None:
-            self.service_client.metadata_cache[self.root / self.key] = (
-                content_settings.content_type
+            # content_type and content_md5 are never None for files in Azure Blob Storage
+            # https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties?tabs=microsoft-entra-id#response-headers
+            content_settings.content_type = (
+                content_settings.content_type or "application/octet-stream"
             )
+            content_settings.content_md5 = content_settings.content_md5 or "some_md5_hash"
+            self.service_client.metadata_cache[path] |= content_settings
 
 
 class MockStorageStreamDownloader:
@@ -175,5 +191,7 @@ def mock_item_paged(root, name_starts_with=None):
                 "name": str(mocked.relative_to(PurePosixPath(root))),
                 "Last-Modified": datetime.fromtimestamp(local.stat().st_mtime),
                 "ETag": "etag",
+                "content_type": "application/octet-stream" if local.is_file() else None,
+                "content_md5": "some_md5_hash" if not local.is_file() else None,
             }
         )


### PR DESCRIPTION
As described in #444, the current mechanism for identifying files and directories in `AzureBlobPath` is unreliable in newer Azure Blob Storage API versions, leading to incorrect `is_file` and `is_dir` results.

This PR fixes this issue by relying on the metadata content, more specifically `content_type` and `content_md5`, which are always `None` for directories, as per: https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties?tabs=microsoft-entra-id#response-headers

Closes #444.