### PR TITLE
perf(az): optimize non-recursive `_list_dir`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
 - fix: use native `exists()` method in `GSClient`. (PR [#420](https://github.com/drivendataorg/cloudpathlib/pull/420))
 - Enhancement: lazy instantiation of default client (PR [#432](https://github.com/drivendataorg/cloudpathlib/issues/432), Issue [#428](https://github.com/drivendataorg/cloudpathlib/issues/428))
 - Adds existence check before downloading in `download_to` (Issue [#430](https://github.com/drivendataorg/cloudpathlib/issues/430), PR [#432](https://github.com/drivendataorg/cloudpathlib/pull/432))
+- perf(az): optimize non-recursive _list_dir (Issue [#446](https://github.com/drivendataorg/cloudpathlib/issues/446), PR [#447](https://github.com/drivendataorg/cloudpathlib/pull/447))
+- fix(az): improve detection of path types (Issue [#444](https://github.com/drivendataorg/cloudpathlib/issues/444), PR [#447](https://github.com/drivendataorg/cloudpathlib/pull/447))
 
 ## v0.18.1 (2024-02-26)
 

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -2,8 +2,7 @@ from datetime import datetime, timedelta
 import mimetypes
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
-
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union, cast
 
 from ..client import Client, register_client_class
 from ..cloudpath import implementation_registry
@@ -156,7 +155,20 @@ class AzureBlobClient(Client):
             return "dir"
 
         try:
-            self._get_metadata(cloud_path)
+            # the result of get_blob_properties is a BlobProperties object (dict mixin)
+            metadata = cast(BlobProperties, self._get_metadata(cloud_path))
+
+            # content_type and content_md5 are never None for files in Azure Blob Storage
+            # if they are None, then the given path is a directory
+            # https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties?tabs=microsoft-entra-id#response-headers
+            is_folder = (
+                metadata.content_settings.content_type is None
+                and metadata.content_settings.content_md5 is None
+            )
+
+            if is_folder:
+                return "dir"
+
             return "file"
         except ResourceNotFoundError:
             prefix = cloud_path.blob


### PR DESCRIPTION
As described in #446, the current implementation of `_list_dir` in the `AzureBlobClient` can be painfully slow for directories with a high level of nesting, even if the result is supposed to be non-recursive.

This PR significantly improves the performance by using a newer portion of the Azure Blob Storage API, more specifically the `BlobServiceClient.walk_blobs` function, which allows for much faster non-recursive iteration over the contents of a directory. Additionally, it is now possible to recursively iterate over the root of an account - over all containers.

Furthermore, the detection of whether a blob is a file or a directory has been improved, using `content_type` and `content_md5` properties as described by the [Azure Blob API](https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties?tabs=microsoft-entra-id#response-headers).

Closes #446.
Closes #444.

------------

Performance before:
```
                                  Performance suite results: (2024-07-02T23:25:47.219870)                                  
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Test Name      ┃ Config Name                ┃ Iterations ┃           Mean ┃              Std ┃            Max ┃ N Items ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ List Folders   │ List shallow recursive     │         10 │ 0:00:01.153302 │ ± 0:00:00.058301 │ 0:00:01.305643 │   5,500 │
│ List Folders   │ List shallow non-recursive │         10 │ 0:00:01.131045 │ ± 0:00:00.019068 │ 0:00:01.168278 │   5,500 │
│ List Folders   │ List normal recursive      │         10 │ 0:00:01.549334 │ ± 0:00:00.016066 │ 0:00:01.581447 │   7,877 │
│ List Folders   │ List normal non-recursive  │         10 │ 0:00:01.463014 │ ± 0:00:00.022756 │ 0:00:01.503776 │     113 │
│ List Folders   │ List deep recursive        │         10 │ 0:00:02.002217 │ ± 0:00:00.032541 │ 0:00:02.059980 │   7,955 │
│ List Folders   │ List deep non-recursive    │         10 │ 0:00:02.002843 │ ± 0:00:00.021002 │ 0:00:02.038868 │      31 │
│ Glob scenarios │ Glob shallow recursive     │         10 │ 0:00:01.233810 │ ± 0:00:00.021087 │ 0:00:01.263742 │   5,500 │
│ Glob scenarios │ Glob shallow non-recursive │         10 │ 0:00:01.223638 │ ± 0:00:00.022161 │ 0:00:01.255687 │   5,500 │
│ Glob scenarios │ Glob normal recursive      │         10 │ 0:00:01.693786 │ ± 0:00:00.017944 │ 0:00:01.719750 │   7,272 │
│ Glob scenarios │ Glob normal non-recursive  │         10 │ 0:00:01.482890 │ ± 0:00:00.013313 │ 0:00:01.495936 │      12 │
│ Glob scenarios │ Glob deep recursive        │         10 │ 0:00:02.246799 │ ± 0:00:00.018432 │ 0:00:02.277186 │   7,650 │
│ Glob scenarios │ Glob deep non-recursive    │         10 │ 0:00:02.019131 │ ± 0:00:00.018071 │ 0:00:02.046828 │      25 │
│ Walk scenarios │ Walk shallow               │         10 │ 0:00:01.130795 │ ± 0:00:00.022412 │ 0:00:01.171678 │   5,500 │
│ Walk scenarios │ Walk normal                │         10 │ 0:00:01.627434 │ ± 0:00:00.018168 │ 0:00:01.650090 │   7,272 │
│ Walk scenarios │ Walk deep                  │         10 │ 0:00:02.088680 │ ± 0:00:00.044334 │ 0:00:02.156224 │   7,650 │
└────────────────┴────────────────────────────┴────────────┴────────────────┴──────────────────┴────────────────┴─────────┘
```
Performance after:
```
                                  Performance suite results: (2024-07-03T09:40:35.151549)                                  
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Test Name      ┃ Config Name                ┃ Iterations ┃           Mean ┃              Std ┃            Max ┃ N Items ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ List Folders   │ List shallow recursive     │         10 │ 0:00:01.148837 │ ± 0:00:00.034477 │ 0:00:01.218684 │   5,500 │
│ List Folders   │ List shallow non-recursive │         10 │ 0:00:01.212517 │ ± 0:00:00.033842 │ 0:00:01.276382 │   5,500 │
│ List Folders   │ List normal recursive      │         10 │ 0:00:01.532350 │ ± 0:00:00.017394 │ 0:00:01.550038 │   7,272 │
│ List Folders   │ List normal non-recursive  │         10 │ 0:00:00.023452 │ ± 0:00:00.009190 │ 0:00:00.049427 │     113 │
│ List Folders   │ List deep recursive        │         10 │ 0:00:01.707918 │ ± 0:00:00.036464 │ 0:00:01.782752 │   7,650 │
│ List Folders   │ List deep non-recursive    │         10 │ 0:00:00.028419 │ ± 0:00:00.004629 │ 0:00:00.039337 │      31 │
│ Glob scenarios │ Glob shallow recursive     │         10 │ 0:00:01.261963 │ ± 0:00:00.034387 │ 0:00:01.343164 │   5,500 │
│ Glob scenarios │ Glob shallow non-recursive │         10 │ 0:00:01.299316 │ ± 0:00:00.024798 │ 0:00:01.353754 │   5,500 │
│ Glob scenarios │ Glob normal recursive      │         10 │ 0:00:01.677940 │ ± 0:00:00.021779 │ 0:00:01.717995 │   7,272 │
│ Glob scenarios │ Glob normal non-recursive  │         10 │ 0:00:00.022214 │ ± 0:00:00.000882 │ 0:00:00.023246 │      12 │
│ Glob scenarios │ Glob deep recursive        │         10 │ 0:00:01.900239 │ ± 0:00:00.023626 │ 0:00:01.947988 │   7,650 │
│ Glob scenarios │ Glob deep non-recursive    │         10 │ 0:00:00.026393 │ ± 0:00:00.000928 │ 0:00:00.028201 │      25 │
│ Walk scenarios │ Walk shallow               │         10 │ 0:00:01.148723 │ ± 0:00:00.019138 │ 0:00:01.190942 │   5,500 │
│ Walk scenarios │ Walk normal                │         10 │ 0:00:01.555491 │ ± 0:00:00.016058 │ 0:00:01.580223 │   7,272 │
│ Walk scenarios │ Walk deep                  │         10 │ 0:00:01.707682 │ ± 0:00:00.017401 │ 0:00:01.733078 │   7,650 │
└────────────────┴────────────────────────────┴────────────┴────────────────┴──────────────────┴────────────────┴─────────┘
```