### PR TITLE
fix(az): correctly remove nested file structures

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 ## v0.18.1 (2024-02-26)
 
 - Fixed import error due to incompatible `google-cloud-storage` by not using `transfer_manager` if it is not available. ([Issue #408](https://github.com/drivendataorg/cloudpathlib/issues/408), [PR #410](https://github.com/drivendataorg/cloudpathlib/pull/410)) 
+- fix(az): correctly remove nested file structures ([Issue #448](https://github.com/drivendataorg/cloudpathlib/issues/448), [PR #449](https://github.com/drivendataorg/cloudpathlib/pull/449)) 
 
 Includes all changes from v0.18.0.
 

--- a/tests/mock_clients/mock_azureblob.py
+++ b/tests/mock_clients/mock_azureblob.py
@@ -148,6 +148,10 @@ class MockContainerClient:
     def list_blobs(self, name_starts_with=None):
         return mock_item_paged(self.root, name_starts_with)
 
+    def delete_blob(self, blob):
+        (self.root / blob).unlink()
+        delete_empty_parents_up_to_root(path=self.root / blob, root=self.root)
+
     def delete_blobs(self, *blobs):
         for blob in blobs:
             (self.root / blob).unlink()


### PR DESCRIPTION
As described in #448, the current `AzureBlobPath.rmtree()` can sometimes fail and must be called again to remove *all* of the file/directory structure.

This PR fixes this issue by first deleting all blobs, then deleting all folders, from the most nested to the least nested ones, and finally removing the root folder. This guarantees that the operation will always succeed.

Closes #448.