### PR TITLE
Make flaky tests more reliable

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,7 @@ pywin32; sys_platform == 'win32'
 rich
 shortuuid
 tabulate
+tenacity
 tqdm
 typer
 wheel


### PR DESCRIPTION
Sometimes tests are flaky, in particular:

 - Custom MinIO S3 rig gets a `BucketAlreadyOwnedByYou` error when it tries to create the bucket.
 - `test_manual_cache_clearing` has directories still exist after `del` (slow garbage collection or OS file system updates?)

Add more resilient retries to both scenarios.