### PR TITLE
#484 Add GSClient timeout support

### DIFF
--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -45,6 +45,7 @@ class GSClient(Client):
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,
         content_type_method: Optional[Callable] = mimetypes.guess_type,
         download_chunks_concurrently_kwargs: Optional[Dict[str, Any]] = None,
+        timeout: float = None,
     ):
         """Class constructor. Sets up a [`Storage
         Client`](https://googleapis.dev/python/storage/latest/client.html).
@@ -85,6 +86,7 @@ class GSClient(Client):
             download_chunks_concurrently_kwargs (Optional[Dict[str, Any]]): Keyword arguments to pass to
                 [`download_chunks_concurrently`](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.transfer_manager#google_cloud_storage_transfer_manager_download_chunks_concurrently)
                 for sliced parallel downloads; Only available in `google-cloud-storage` version 2.7.0 or later, otherwise ignored and a warning is emitted.
+            timeout (float): Cloud Storage [timeout value](https://cloud.google.com/python/docs/reference/storage/1.39.0/retry_timeout)
         """
         if application_credentials is None:
             application_credentials = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
@@ -102,6 +104,10 @@ class GSClient(Client):
                 self.client = StorageClient.create_anonymous_client()
 
         self.download_chunks_concurrently_kwargs = download_chunks_concurrently_kwargs
+        self.timeout = timeout
+        self.blob_kwargs = {}
+        if self.timeout:
+            self.blob_kwargs["timeout"] = self.timeout
 
         super().__init__(
             local_cache_dir=local_cache_dir,
@@ -128,7 +134,6 @@ class GSClient(Client):
         blob = bucket.get_blob(cloud_path.blob)
 
         local_path = Path(local_path)
-
         if transfer_manager is not None and self.download_chunks_concurrently_kwargs is not None:
             transfer_manager.download_chunks_concurrently(
                 blob, local_path, **self.download_chunks_concurrently_kwargs
@@ -139,7 +144,7 @@ class GSClient(Client):
                     "Ignoring `download_chunks_concurrently_kwargs` for version of google-cloud-storage that does not support them (<2.7.0)."
                 )
 
-            blob.download_to_filename(local_path)
+            blob.download_to_filename(local_path, **self.blob_kwargs)
 
         return local_path
 
@@ -246,7 +251,7 @@ class GSClient(Client):
             dst_bucket = self.client.bucket(dst.bucket)
 
             src_blob = src_bucket.get_blob(src.blob)
-            src_bucket.copy_blob(src_blob, dst_bucket, dst.blob)
+            src_bucket.copy_blob(src_blob, dst_bucket, dst.blob, **self.blob_kwargs)
 
             if remove_src:
                 src_blob.delete()
@@ -279,7 +284,7 @@ class GSClient(Client):
             content_type, _ = self.content_type_method(str(local_path))
             extra_args["content_type"] = content_type
 
-        blob.upload_from_filename(str(local_path), **extra_args)
+        blob.upload_from_filename(str(local_path), **extra_args, **self.blob_kwargs)
         return cloud_path
 
     def _get_public_url(self, cloud_path: GSPath) -> str:

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -107,7 +107,7 @@ class GSClient(Client):
                 self.client = StorageClient.create_anonymous_client()
 
         self.download_chunks_concurrently_kwargs = download_chunks_concurrently_kwargs
-        self.blob_kwargs = {}
+        self.blob_kwargs: dict[str, Any] = {}
         if timeout is not None:
             self.timeout: float = timeout
             self.blob_kwargs["timeout"] = self.timeout

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -45,7 +45,7 @@ class GSClient(Client):
         local_cache_dir: Optional[Union[str, os.PathLike]] = None,
         content_type_method: Optional[Callable] = mimetypes.guess_type,
         download_chunks_concurrently_kwargs: Optional[Dict[str, Any]] = None,
-        timeout: float = None,
+        timeout: Optional[float] = None,
     ):
         """Class constructor. Sets up a [`Storage
         Client`](https://googleapis.dev/python/storage/latest/client.html).
@@ -86,7 +86,7 @@ class GSClient(Client):
             download_chunks_concurrently_kwargs (Optional[Dict[str, Any]]): Keyword arguments to pass to
                 [`download_chunks_concurrently`](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.transfer_manager#google_cloud_storage_transfer_manager_download_chunks_concurrently)
                 for sliced parallel downloads; Only available in `google-cloud-storage` version 2.7.0 or later, otherwise ignored and a warning is emitted.
-            timeout (float): Cloud Storage [timeout value](https://cloud.google.com/python/docs/reference/storage/1.39.0/retry_timeout)
+            timeout (Optional[float]): Cloud Storage [timeout value](https://cloud.google.com/python/docs/reference/storage/1.39.0/retry_timeout)
         """
         if application_credentials is None:
             application_credentials = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -13,6 +13,7 @@ from .gspath import GSPath
 try:
     if TYPE_CHECKING:
         from google.auth.credentials import Credentials
+        from google.api_core.retry import Retry
 
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud.storage import Client as StorageClient
@@ -46,6 +47,7 @@ class GSClient(Client):
         content_type_method: Optional[Callable] = mimetypes.guess_type,
         download_chunks_concurrently_kwargs: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
+        retry: Optional["Retry"] = None
     ):
         """Class constructor. Sets up a [`Storage
         Client`](https://googleapis.dev/python/storage/latest/client.html).
@@ -87,6 +89,7 @@ class GSClient(Client):
                 [`download_chunks_concurrently`](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.transfer_manager#google_cloud_storage_transfer_manager_download_chunks_concurrently)
                 for sliced parallel downloads; Only available in `google-cloud-storage` version 2.7.0 or later, otherwise ignored and a warning is emitted.
             timeout (Optional[float]): Cloud Storage [timeout value](https://cloud.google.com/python/docs/reference/storage/1.39.0/retry_timeout)
+            retry (Optional[google.api_core.retry.Retry]): Cloud Storage [retry configuration](https://cloud.google.com/python/docs/reference/storage/1.39.0/retry_timeout#configuring-retries)
         """
         if application_credentials is None:
             application_credentials = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
@@ -105,9 +108,12 @@ class GSClient(Client):
 
         self.download_chunks_concurrently_kwargs = download_chunks_concurrently_kwargs
         self.timeout = timeout
+        self.retry = retry
         self.blob_kwargs = {}
         if self.timeout:
             self.blob_kwargs["timeout"] = self.timeout
+        if self.retry:
+            self.blob_kwargs["retry"] = self.retry
 
         super().__init__(
             local_cache_dir=local_cache_dir,

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -107,12 +107,12 @@ class GSClient(Client):
                 self.client = StorageClient.create_anonymous_client()
 
         self.download_chunks_concurrently_kwargs = download_chunks_concurrently_kwargs
-        self.timeout = timeout
-        self.retry = retry
         self.blob_kwargs = {}
-        if self.timeout:
+        if timeout is not None:
+            self.timeout: float = timeout
             self.blob_kwargs["timeout"] = self.timeout
-        if self.retry:
+        if retry is not None:
+            self.retry: Retry = retry
             self.blob_kwargs["retry"] = self.retry
 
         super().__init__(

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -47,7 +47,7 @@ class GSClient(Client):
         content_type_method: Optional[Callable] = mimetypes.guess_type,
         download_chunks_concurrently_kwargs: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        retry: Optional["Retry"] = None
+        retry: Optional["Retry"] = None,
     ):
         """Class constructor. Sets up a [`Storage
         Client`](https://googleapis.dev/python/storage/latest/client.html).


### PR DESCRIPTION
Adds GSClient option to include a timeout in seconds. When using google.cloud.storage, it's possible to manually increase the timeout from the default of 60 seconds, but with cloudpathlib it's not possible to tweak this. This makes, for example, uploading larger files with slow internet connection impossible to achieve using cloudpathlib

Closes #484 

----------------

Contributor checklist:

 - [x] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [x] Confirmed PR is rebased onto the latest base
 - [x] Confirmed failure before change and success after change
 - [x] Any generic new functionality is replicated across cloud providers if necessary
 - [x] Tested manually against live server backend for at least one provider
 - [x] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [x] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.


Usage: 
```py
from cloudpathlib import CloudPath, GSClient
client = GSClient(timeout=.00001)
with CloudPath("gs://path/to/test_file.txt", client=client).open("wb") as f:
    f.write(os.urandom(10000000))
# Raises Timeout Error
```
