### PR TITLE
Azure support for `..` in path

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed `CloudPath(...) / other` to correctly attempt to fall back on `other`'s `__rtruediv__` implementation, in order to support classes that explicitly support the `/` with a `CloudPath` instance. Previously, this would always raise a `TypeError` if `other` were not a `str` or `PurePosixPath`. (PR [#479](https://github.com/drivendataorg/cloudpathlib/pull/479))
+- Fixed `AzureBlobPath(...).blob` to correctly resolves path to the blob for situations when specified path contains `..`.
 
 ## v0.20.0 (2024-10-18)
 

--- a/cloudpathlib/azure/azblobpath.py
+++ b/cloudpathlib/azure/azblobpath.py
@@ -96,7 +96,11 @@ class AzureBlobPath(CloudPath):
 
     @property
     def blob(self) -> str:
-        key = self._no_prefix_no_drive
+        key = (
+            Path(self._no_prefix_no_drive).resolve().as_posix()
+            if self._no_prefix_no_drive
+            else self._no_prefix_no_drive
+        )
 
         # key should never have starting slash for
         if key.startswith("/"):


### PR DESCRIPTION
When looking into #494, I found several possible solutions.

1) The proposed one (resolve correctly blob path)
2) Create alternative property, say `AzureBlobPath.blob_resolved` and use in on line https://github.com/drivendataorg/cloudpathlib/blob/master/cloudpathlib/azure/azblobclient.py#L337

I tested the code is working in my specific situation and all tests are still passing.

Closes #494 