### PR TITLE
batch deletions on azure / limited to 256 - Closes #509

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cloudpathlib Changelog
 
+## Unreleased
+
+- Fixed `rmtree` fail on Azure with no `hns` and more than 256 blobs to drop
+
 ## v0.21.0 (2025-03-03)
 
 - Removed support for deprecated env var that had a typo (`CLOUPATHLIB_FILE_CACHE_MODE`; you should use `CLOUDPATHLIB_FILE_CACHE_MODE`).

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -4,6 +4,7 @@ import os
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from itertools import batched
 
 try:
     from typing import cast
@@ -437,11 +438,20 @@ class AzureBlobClient(Client):
                 _hns_rmtree(self.data_lake_client, cloud_path.container, cloud_path.blob)
                 return
 
-            blobs = [
-                b.blob for b, is_dir in self._list_dir(cloud_path, recursive=True) if not is_dir
-            ]
+
+            def batches():
+                yield from batched(
+                    (
+                        b.blob
+                        for b, is_dir in self._list_dir(cloud_path, recursive=True)
+                        if not is_dir
+                    ),
+                    256,
+                )
+
             container_client = self.service_client.get_container_client(cloud_path.container)
-            container_client.delete_blobs(*blobs)
+            for batch in batches():
+                container_client.delete_blobs(*batch)
         elif file_or_dir == "file":
             blob = self.service_client.get_blob_client(
                 container=cloud_path.container, blob=cloud_path.blob

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -438,7 +438,6 @@ class AzureBlobClient(Client):
                 _hns_rmtree(self.data_lake_client, cloud_path.container, cloud_path.blob)
                 return
 
-
             def batches():
                 yield from batched(
                     (

--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -438,17 +438,11 @@ class AzureBlobClient(Client):
                 _hns_rmtree(self.data_lake_client, cloud_path.container, cloud_path.blob)
                 return
 
-            def batches():
-                all_blobs = (
-                    b.blob
-                    for b, is_dir in self._list_dir(cloud_path, recursive=True)
-                    if not is_dir
-                )
-                while batch := tuple(islice(all_blobs, 256)):
-                    yield batch
-
+            blobs = (
+                b.blob for b, is_dir in self._list_dir(cloud_path, recursive=True) if not is_dir
+            )
             container_client = self.service_client.get_container_client(cloud_path.container)
-            for batch in batches():
+            while batch := tuple(islice(blobs, 256)):
                 container_client.delete_blobs(*batch)
         elif file_or_dir == "file":
             blob = self.service_client.get_blob_client(

--- a/tests/test_azure_specific.py
+++ b/tests/test_azure_specific.py
@@ -206,3 +206,13 @@ def test_adls_gen2_rename(azure_gen2_rig):
     p2 = p.rename(azure_gen2_rig.create_cloud_path("dir2"))
     assert not p.exists()
     assert p2.exists()
+
+
+def test_batched_rmtree_no_hns(azure_rig):
+    p = azure_rig.create_cloud_path("new_dir")
+
+    p.mkdir()
+    for i in range(400):
+        (p / f"{i}.txt").write_text("content")
+    p.rmtree()
+    assert not p.exists()


### PR DESCRIPTION
One of the implementations of delete folder on azure lists all the blobs and delete them directly. The delete request on azure blobs is limited to 256 objects per request (https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.containerclient?view=azure-python#azure-storage-blob-containerclient-delete-blobs)
The proposal is to batch the call

----------------

Contributor checklist:

 - [X] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [X] Confirmed PR is rebased onto the latest base
 - [x] Confirmed failure before change and success after change
 - [x] Any generic new functionality is replicated across cloud providers if necessary
 - [x] Tested manually against live server backend for at least one provider
 - [x] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [x] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.