### PR TITLE
Only fail codecov if push or pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ (github.event_name == 'push' && true) || (github.event_name == 'pull_request' && true) || false }}
 
   extras-test:
     name: Test independent installs of clients


### PR DESCRIPTION
Should reduce the noise we get from Codecov being flaky. 

Demo in another repo:

- [`pull_request`](https://github.com/jayqi/reprexlite/actions/runs/13778996221/job/38533672003#step:7:4)
- [`push`](https://github.com/jayqi/reprexlite/actions/runs/13779037404/job/38533781917#step:7:4) (when merging into main branch)
- [`workflow_dispatch`](https://github.com/jayqi/reprexlite/actions/runs/13779072478/job/38533879886#step:7:4)