### PR TITLE
Refactor GS authentication to use default credentials

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed issue with GS credentials, using default auth enables a wider set of authentication methods in GS
 - Fixed `rmtree` fail on Azure with no `hns` and more than 256 blobs to drop (Issue [#509](https://github.com/drivendataorg/cloudpathlib/issues/509), PR [#508](https://github.com/drivendataorg/cloudpathlib/pull/508), thanks @alikefia)
 
 ## v0.21.0 (2025-03-03)

--- a/cloudpathlib/gs/gsclient.py
+++ b/cloudpathlib/gs/gsclient.py
@@ -15,6 +15,7 @@ try:
         from google.auth.credentials import Credentials
         from google.api_core.retry import Retry
 
+    from google.auth import default as google_default_auth
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud.storage import Client as StorageClient
 
@@ -99,7 +100,8 @@ class GSClient(Client):
         elif credentials is not None:
             self.client = StorageClient(credentials=credentials, project=project)
         elif application_credentials is not None:
-            self.client = StorageClient.from_service_account_json(application_credentials)
+            credentials, project = google_default_auth()
+            self.client = StorageClient(credentials=credentials, project=project)
         else:
             try:
                 self.client = StorageClient()


### PR DESCRIPTION
This enables federated identity, there's a caveat to this PR which the maintainers may want to be aware of around the validation of the `GOOGLE_APPLICATION_CREDENTIALS`.

See https://cloud.google.com/docs/authentication/client-libraries#validate_other_credential_configurations for further details.

Closes #390

----------------

Contributor checklist:

 - [x] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [x] Confirmed PR is rebased onto the latest base
 - [x] Confirmed failure before change and success after change
 - [ ] Any generic new functionality is replicated across cloud providers if necessary
 - [x] Tested manually against live server backend for at least one provider
 - [ ] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [x] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.