### PR TITLE
Rerun flaky tests when live cloud

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ pytest-cases
 pytest-cov
 pytest-duration-insights
 pytest-reportlog
+pytest-rerunfailures
 pytest-xdist
 python-dotenv
 pywin32; sys_platform == 'win32'

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -319,6 +319,7 @@ def test_environment_variable_local_cache_dir(rig: CloudProviderTestRig, tmpdir)
         os.environ["CLOUDPATHLIB_LOCAL_CACHE_DIR"] = original_env_setting
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1, condition=os.getenv("USE_LIVE_CLOUD") == "1")
 def test_environment_variables_force_overwrite_from(rig: CloudProviderTestRig, tmpdir):
     # environment instantiation
     original_env_setting = os.environ.get("CLOUDPATHLIB_FORCE_OVERWRITE_FROM_CLOUD", "")
@@ -354,6 +355,7 @@ def test_environment_variables_force_overwrite_from(rig: CloudProviderTestRig, t
         os.environ["CLOUDPATHLIB_FORCE_OVERWRITE_FROM_CLOUD"] = original_env_setting
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1, condition=os.getenv("USE_LIVE_CLOUD") == "1")
 def test_environment_variables_force_overwrite_to(rig: CloudProviderTestRig, tmpdir):
     # environment instantiation
     original_env_setting = os.environ.get("CLOUDPATHLIB_FORCE_OVERWRITE_TO_CLOUD", "")


### PR DESCRIPTION
Use [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures) to rerun flaky tests when running on live cloud services. 