### PR TITLE
POC - make CloudPath more Path-like using abc Protocol interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ ENV/
 
 # IDE settings
 .vscode/
+*.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,10 @@ help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .
+
+install-dev: clean ## install the package and development requirements
+	pip install -e .
 
 lint: ## check style with black, flake8, and mypy
 	black --check cloudpathlib tests docs

--- a/cloudpathlib/anypath.py
+++ b/cloudpathlib/anypath.py
@@ -1,7 +1,16 @@
 import os
+import sys
 from abc import ABC
 from pathlib import Path
 from typing import Any, Union
+
+if sys.version_info >= (3, 14, 0):
+    if sys.version_info >= (3, 14, 4):
+        from pathlib._abc import ReadablePath, WritablePath
+    else:
+        from pathlib._abc import PathBase as ReadablePath, PathBase as WritablePath
+else:
+    from pathlib_abc import ReadablePath, WritablePath
 
 from .cloudpath import InvalidPrefixError, CloudPath
 from .exceptions import AnyPathTypeError
@@ -90,3 +99,15 @@ def to_anypath(s: Union[str, os.PathLike]) -> Union[CloudPath, Path]:
         return s
 
     return AnyPath(s)  # type: ignore
+
+
+class PathBase(ReadablePath, WritablePath):
+    """
+    A base class for path-like objects that can be used with cloud storage.
+    This class is a subclass of Readable
+    and WritablePath from pathlib_abc, which provides a common interface
+    for path-like objects that can be read from and written to.
+    """
+
+
+PathBase.register(Path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "typing-extensions>4 ; python_version < '3.11'",
+  "typing_extensions>4 ; python_version < '3.11'",
+  "pathlib-abc ~= ; python_version < '3.14'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_anypath.py
+++ b/tests/test_anypath.py
@@ -64,3 +64,17 @@ def test_anypath_bad_input():
 
 def test_anypath_subclass_anypath():
     assert issubclass(AnyPath, AnyPath)
+
+
+def test__anypathbase__subclassing_works_correctly(rig):
+    from cloudpathlib.anypathbase import PathBase
+
+    cloudpath = rig.create_cloud_path("a/b/c")
+
+    localpath = Path("a/b/c")
+
+    assert isinstance(cloudpath, PathBase)
+    assert isinstance(localpath, PathBase)
+
+    assert isinstance(cloudpath, os.PathLike)
+    assert isinstance(localpath, os.PathLike)


### PR DESCRIPTION
- **Update .gitignore and Makefile for improved installation commands**
- **Enhance cloudpathlib with PathBase integration and CloudPathInfo class**

### What's in this change?

This is just a proof of concept for using abstract base class for pathlib.Path introduced in 3.14 and available as a backport from `pathlib-abc`.

It is not intended to merge rather to show the feasibility of implementing `CloudPath` as a Path-like interface 

Relates to https://github.com/drivendataorg/cloudpathlib/issues/347

----------------

Contributor checklist:

 - [x] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [ ] Confirmed PR is rebased onto the latest base
 - [ ] Confirmed failure before change and success after change
 - [ ] Any generic new functionality is replicated across cloud providers if necessary
 - [ ] Tested manually against live server backend for at least one provider
 - [ ] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [ ] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.