### PR TITLE
Typing failure fix

### DIFF
--- a/cloudpathlib/azure/azblobclient.py
+++ b/cloudpathlib/azure/azblobclient.py
@@ -358,9 +358,9 @@ class AzureBlobClient(Client):
 
         else:
             if not recursive:
-                blobs = container_client.walk_blobs(name_starts_with=prefix)
+                blobs = container_client.walk_blobs(name_starts_with=prefix)  # type: ignore
             else:
-                blobs = container_client.list_blobs(name_starts_with=prefix)
+                blobs = container_client.list_blobs(name_starts_with=prefix)  # type: ignore
 
             for blob in blobs:
                 # walk_blobs returns folders with a trailing slash


### PR DESCRIPTION
Azure SDK typing indicates return type `ItemPaged[BlobProperties | BlobPrefix]` for `walk_blobs`.

Per [this issue](https://github.com/Azure/azure-sdk-for-python/issues/40873), `BlobPrefix` is only returned if the `delimiter` kwarg is passed. Since we do not do that, we can safely ignore the typing issue and both `walk_blobs` and `list_blobs` will return `ItemPaged[BlobProperties]` as we expect.

Closes #523