### PR TITLE
WIP Support 3.14

### DIFF
--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: "pip" # caching pip dependencies
           cache-dependency-path: |
             pyproject.toml

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: "pip" # caching pip dependencies
           cache-dependency-path: |
             pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python and uv
-        uses: drivendataorg/setup-python-uv-action@v1
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python and uv
-        uses: drivendataorg/setup-python-uv-action@v1
+        uses: astral-sh/setup-uv@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python and uv
-        uses: drivendataorg/setup-python-uv-action@v1
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
 
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python and uv
-        uses: drivendataorg/setup-python-uv-action@v1
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Set up Python and uv
         uses: astral-sh/setup-uv@v6
         with:
+          activate-environment: true
           python-version: "3.11"
 
       - name: Install dependencies
@@ -43,9 +44,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python and uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: true
 
       - name: Install dependencies
         run: |
@@ -84,6 +86,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
+          activate-environment: true
 
       - name: Install dependencies
         run: |
@@ -144,6 +147,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
+          activate-environment: true
 
       - name: Build cloudpathlib
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,13 +52,7 @@ jobs:
           activate-environment: true
           enable-cache: true
 
-      - name: Install dependencies (Python 3.14)
-        if: matrix.python-version == '3.14'
-        run: |
-          uv pip install --pre -r requirements-dev.txt
-
       - name: Install dependencies (other Python versions)
-        if: matrix.python-version != '3.14'
         run: |
           uv pip install -r requirements-dev.txt
 
@@ -66,18 +60,7 @@ jobs:
         run: |
           make test
 
-      - name: Build distribution and test installation (Python 3.14)
-        if: matrix.python-version == '3.14'
-        shell: bash
-        run: |
-          make dist
-          uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
-          python -c "import cloudpathlib"
-          uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
-          python -c "import cloudpathlib"
-
       - name: Build distribution and test installation (other Python versions)
-        if: matrix.python-version != '3.14'
         shell: bash
         run: |
           make dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,33 +49,39 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
 
-      - name: Install dependencies
+      - name: Install dependencies (Python 3.14)
+        if: matrix.python-version == '3.14'
         run: |
-          if [ "${{ matrix.python-version }}" = "3.14" ]; then
-            uv pip install --pre -r requirements-dev.txt
-          else
-            uv pip install -r requirements-dev.txt
-          fi
+          uv pip install --pre -r requirements-dev.txt
+
+      - name: Install dependencies (other Python versions)
+        if: matrix.python-version != '3.14'
+        run: |
+          uv pip install -r requirements-dev.txt
 
       - name: Run mocked tests
         run: |
           make test
 
-      - name: Build distribution and test installation
+      - name: Build distribution and test installation (Python 3.14)
+        if: matrix.python-version == '3.14'
         shell: bash
         run: |
           make dist
-          if [ "${{ matrix.python-version }}" = "3.14" ]; then
-            uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
-            python -c "import cloudpathlib"
-            uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
-            python -c "import cloudpathlib"
-          else
-            uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
-            python -c "import cloudpathlib"
-            uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
-            python -c "import cloudpathlib"
-          fi
+          uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
+          python -c "import cloudpathlib"
+          uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
+          python -c "import cloudpathlib"
+
+      - name: Build distribution and test installation (other Python versions)
+        if: matrix.python-version != '3.14'
+        shell: bash
+        run: |
+          make dist
+          uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
+          python -c "import cloudpathlib"
+          uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
+          python -c "import cloudpathlib"
 
       - name: Upload coverage to codecov
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Python and uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           activate-environment: true
 
       - name: Install dependencies
@@ -166,7 +166,7 @@ jobs:
       - name: Set up Python and uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           activate-environment: true
 
       - name: Build cloudpathlib

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
+          python-preference: "only-managed"
 
       - name: Install dependencies (Python 3.14)
         if: matrix.python-version == '3.14'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
           python-preference: "only-managed"
+          use-latest-python: true
 
       - name: Install dependencies (Python 3.14)
         if: matrix.python-version == '3.14'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+    env:
+      UV_MANAGED_PYTHON: true
 
     steps:
       - uses: actions/checkout@v4
@@ -48,8 +50,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
-          python-preference: "only-managed"
-          use-latest-python: true
+          enable-cache: true
 
       - name: Install dependencies (Python 3.14)
         if: matrix.python-version == '3.14'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -r requirements-dev.txt
+          if [ "${{ matrix.python-version }}" = "3.14" ]; then
+            uv pip install --pre -r requirements-dev.txt
+          else
+            uv pip install -r requirements-dev.txt
+          fi
 
       - name: Run mocked tests
         run: |
@@ -61,10 +65,17 @@ jobs:
         shell: bash
         run: |
           make dist
-          uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
-          python -c "import cloudpathlib"
-          uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
-          python -c "import cloudpathlib"
+          if [ "${{ matrix.python-version }}" = "3.14" ]; then
+            uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
+            python -c "import cloudpathlib"
+            uv pip install --pre cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
+            python -c "import cloudpathlib"
+          else
+            uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.whl') --no-deps --force-reinstall
+            python -c "import cloudpathlib"
+            uv pip install cloudpathlib@$(find dist -name 'cloudpathlib*.tar.gz') --no-deps --force-reinstall
+            python -c "import cloudpathlib"
+          fi
 
       - name: Upload coverage to codecov
         if: matrix.os == 'ubuntu-latest'

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # cloudpathlib Changelog
 
-## UNRELEASED
+## v0.23.0 (2025-10-07)
 
 - Added support for Python 3.14 (Issue [#529](https://github.com/drivendataorg/cloudpathlib/issues/529), PR [#530](https://github.com/drivendataorg/cloudpathlib/pull/530))
   - Changed `CloudPath.copy` to have the first parameter named `target` instead of `destination` and added new `follow_symlinks` and `preserve_metadata` kwargs. **Breaking change for users that relied on the first parameter being named `destination` instead of `target`.**
@@ -9,7 +9,6 @@
   - Added `CloudPath.move_into` to move a file or directory into another file or directory.
   - Added `CloudPathInfo` and `CloudPath.info` to get information about a file or directory.
   - Added additional no-op kwargs to `mkdir`, `touch`, `glob`, `rglob`, `stat` to match pathlib.
-  - Added `pathlib-abc` dependency for Python < 3.14 for `PathInfo` protocol.
 
 ## v0.22.0 (2025-08-29)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,13 @@
 ## UNRELEASED
 
 - Added support for Python 3.14 (Issue [#529](https://github.com/drivendataorg/cloudpathlib/issues/529), PR [#530](https://github.com/drivendataorg/cloudpathlib/pull/530))
+  - Changed `CloudPath.copy` to have the first parameter named `target` instead of `destination` and added new `follow_symlinks` and `preserve_metadata` kwargs.
+  - Added `CloudPath.copy_into` to copy a file or directory into another file or directory.
+  - Added `CloudPath.move` to move a file or directory to another location.
+  - Added `CloudPath.move_into` to move a file or directory into another file or directory.
+  - Added `CloudPathInfo` and `CloudPath.info` to get information about a file or directory.
+  - Added additional no-op kwargs to `mkdir`, `touch`, `glob`, `rglob`, `stat` to match pathlib.
+  - Added `pathlib-abc` dependency for Python < 3.14 for `PathInfo` protocol.
 
 ## v0.22.0 (2025-08-29)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cloudpathlib Changelog
 
+## UNRELEASED
+
+- Added support for Python 3.14 (Issue [#529](https://github.com/drivendataorg/cloudpathlib/issues/529), PR [#530](https://github.com/drivendataorg/cloudpathlib/pull/530))
+
 ## v0.22.0 (2025-08-29)
 
 - Fixed issue with GS credentials, using default auth enables a wider set of authentication methods in GS (Issue [#390](https://github.com/drivendataorg/cloudpathlib/issues/390), PR [#514](https://github.com/drivendataorg/cloudpathlib/pull/514), thanks @ljyanesm) 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## UNRELEASED
 
 - Added support for Python 3.14 (Issue [#529](https://github.com/drivendataorg/cloudpathlib/issues/529), PR [#530](https://github.com/drivendataorg/cloudpathlib/pull/530))
-  - Changed `CloudPath.copy` to have the first parameter named `target` instead of `destination` and added new `follow_symlinks` and `preserve_metadata` kwargs.
+  - Changed `CloudPath.copy` to have the first parameter named `target` instead of `destination` and added new `follow_symlinks` and `preserve_metadata` kwargs. **Breaking change for users that relied on the first parameter being named `destination` instead of `target`.**
   - Added `CloudPath.copy_into` to copy a file or directory into another file or directory.
   - Added `CloudPath.move` to move a file or directory to another location.
   - Added `CloudPath.move_into` to move a file or directory into another file or directory.

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ clean-build: ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
-	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -path ./venv -prune -name '*.egg-info' -exec rm -fr {} +
+	find . -path ./venv -prune -name '*.egg' -exec rm -f {} +
 
 clean-pyc: ## remove Python file artifacts
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rm -fr {} +
+	find . -path ./venv -prune -name '*.pyc' -exec rm -f {} +
+	find . -path ./venv -prune -name '*.pyo' -exec rm -f {} +
+	find . -path ./venv -prune -name '*~' -exec rm -f {} +
+	find . -path ./venv -prune -name '__pycache__' -exec rm -fr {} +
 
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ clean-build: ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
-	find . -path ./venv -prune -name '*.egg-info' -exec rm -fr {} +
-	find . -path ./venv -prune -name '*.egg' -exec rm -f {} +
+	find . -path ./.venv -prune -o -name '*.egg-info' -exec rm -fr {} +
+	find . -path ./.venv -prune -o -name '*.egg' -exec rm -rf {} +
 
 clean-pyc: ## remove Python file artifacts
-	find . -path ./venv -prune -name '*.pyc' -exec rm -f {} +
-	find . -path ./venv -prune -name '*.pyo' -exec rm -f {} +
-	find . -path ./venv -prune -name '*~' -exec rm -f {} +
-	find . -path ./venv -prune -name '__pycache__' -exec rm -fr {} +
+	find . -path ./.venv -prune -o -name '*.pyc' -exec rm -f {} +
+	find . -path ./.venv -prune -o -name '*.pyo' -exec rm -f {} +
+	find . -path ./.venv -prune -o -name '*~' -exec rm -f {} +
+	find . -path ./.venv -prune -o -name '__pycache__' -exec rm -fr {} +
 
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/

--- a/cloudpathlib/azure/azblobpath.py
+++ b/cloudpathlib/azure/azblobpath.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from cloudpathlib.exceptions import CloudPathIsADirectoryError
 
@@ -39,10 +39,10 @@ class AzureBlobPath(CloudPath):
     def drive(self) -> str:
         return self.container
 
-    def mkdir(self, parents=False, exist_ok=False):
+    def mkdir(self, parents=False, exist_ok=False, mode: Optional[Any] = None):
         self.client._mkdir(self, parents=parents, exist_ok=exist_ok)
 
-    def touch(self, exist_ok: bool = True):
+    def touch(self, exist_ok: bool = True, mode: Optional[Any] = None):
         if self.exists():
             if not exist_ok:
                 raise FileExistsError(f"File exists: {self}")
@@ -56,7 +56,7 @@ class AzureBlobPath(CloudPath):
 
             tf.cleanup()
 
-    def stat(self):
+    def stat(self, follow_symlinks=True):
         try:
             meta = self.client._get_metadata(self)
         except ResourceNotFoundError:

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -1147,23 +1147,14 @@ class CloudPath(metaclass=CloudPathMeta):
         if not self.exists():
             raise ValueError(f"Path {self} must exist to copy.")
 
+        destination = anypath.to_anypath(target)
+
         if self.is_dir():
-            # Handle the target type for copytree
-            if isinstance(target, (str, os.PathLike)):
-                target_path = anypath.to_anypath(target)
-            else:
-                target_path = target
             result = self.copytree(
-                target_path,  # type: ignore[arg-type]
+                destination,  # type: ignore[arg-type]
                 force_overwrite_to_cloud=force_overwrite_to_cloud,
             )
             return cast(Union[Path, Self], result)
-
-        # handle string version of cloud paths + local paths
-        if isinstance(target, (str, os.PathLike)):
-            destination = anypath.to_anypath(target)
-        else:
-            destination = target
 
         if not isinstance(destination, CloudPath):
             return self.download_to(destination)
@@ -1285,11 +1276,7 @@ class CloudPath(metaclass=CloudPathMeta):
         force_overwrite_to_cloud: Optional[bool] = None,
     ) -> Union[Path, Self]:
         """Copy self into target directory, preserving the filename."""
-        # Handle the division operation properly based on type
-        if isinstance(target_dir, (str, os.PathLike)):
-            target_path = anypath.to_anypath(target_dir) / self.name
-        else:
-            target_path = target_dir / self.name
+        target_path = anypath.to_anypath(target_dir) / self.name
 
         result = self._copy(
             target_path,
@@ -1319,7 +1306,7 @@ class CloudPath(metaclass=CloudPathMeta):
     @overload
     def copytree(
         self,
-        destination: str,
+        destination: Union[str, os.PathLike, Self],
         force_overwrite_to_cloud: Optional[bool] = None,
         ignore: Optional[Callable[[str, Iterable[str]], Container[str]]] = None,
     ) -> Union[Path, "CloudPath"]: ...
@@ -1331,9 +1318,7 @@ class CloudPath(metaclass=CloudPathMeta):
                 f"Origin path {self} must be a directory. To copy a single file use the method copy."
             )
 
-        # handle string version of cloud paths + local paths
-        if isinstance(destination, (str, os.PathLike)):
-            destination = anypath.to_anypath(destination)
+        destination = anypath.to_anypath(destination)
 
         if destination.exists() and destination.is_file():
             raise CloudPathFileExistsError(
@@ -1443,11 +1428,7 @@ class CloudPath(metaclass=CloudPathMeta):
         force_overwrite_to_cloud: Optional[bool] = None,
     ) -> Union[Path, Self]:
         """Move self into target directory, preserving the filename and removing the source."""
-        # Handle the division operation properly based on type
-        if isinstance(target_dir, (str, os.PathLike)):
-            target_path = anypath.to_anypath(target_dir) / self.name
-        else:
-            target_path = target_dir / self.name
+        target_path = anypath.to_anypath(target_dir) / self.name
 
         result = self._copy(
             target_path,

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -68,11 +68,16 @@ elif sys.version_info[:2] == (3, 12):
     from pathlib import _PathParents  # type: ignore[attr-defined]
     from pathlib import posixpath as _posix_flavour  # type: ignore[attr-defined]
     from pathlib import _make_selector  # type: ignore[attr-defined]
-elif sys.version_info >= (3, 13):
+elif sys.version_info[:2] == (3, 13):
     from pathlib._local import _PathParents
     import posixpath as _posix_flavour  # type: ignore[attr-defined]   # noqa: F811
 
     from .legacy.glob import _make_selector  # noqa: F811
+elif sys.version_info >= (3, 14):
+    from pathlib import _PathParents
+    import posixpath as _posix_flavour  # type: ignore[attr-defined]
+    from .legacy.glob import _make_selector  # noqa: F811
+
 
 
 from cloudpathlib.enums import FileCacheMode

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -74,10 +74,9 @@ elif sys.version_info[:2] == (3, 13):
 
     from .legacy.glob import _make_selector  # noqa: F811
 elif sys.version_info >= (3, 14):
-    from pathlib import _PathParents
+    from pathlib import _PathParents  # type: ignore[attr-defined]
     import posixpath as _posix_flavour  # type: ignore[attr-defined]
     from .legacy.glob import _make_selector  # noqa: F811
-
 
 
 from cloudpathlib.enums import FileCacheMode

--- a/cloudpathlib/cloudpath_info.py
+++ b/cloudpathlib/cloudpath_info.py
@@ -1,17 +1,12 @@
 from functools import lru_cache
-import sys
 from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 14):
-    from pathlib_abc import PathInfo
-else:
-    from pathlib.types import PathInfo
 
 if TYPE_CHECKING:
     from .cloudpath import CloudPath
 
 
-class CloudPathInfo(PathInfo):
+class CloudPathInfo:
     """Implementation of `PathInfo` protocol for `CloudPath`.
 
     Caches the results of the methods for efficient re-use.

--- a/cloudpathlib/cloudpath_info.py
+++ b/cloudpathlib/cloudpath_info.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 import sys
 from typing import TYPE_CHECKING
 
-if sys.version_info <= (3, 14):
+if sys.version_info < (3, 14):
     from pathlib_abc import PathInfo
 else:
     from pathlib.types import PathInfo

--- a/cloudpathlib/cloudpath_info.py
+++ b/cloudpathlib/cloudpath_info.py
@@ -1,0 +1,36 @@
+from functools import lru_cache
+import sys
+from typing import TYPE_CHECKING
+
+if sys.version_info <= (3, 14):
+    from pathlib_abc import PathInfo
+else:
+    from pathlib.types import PathInfo
+
+if TYPE_CHECKING:
+    from .cloudpath import CloudPath
+
+
+class CloudPathInfo(PathInfo):
+    """Implementation of `PathInfo` protocol for `CloudPath`.
+
+    Caches the results of the methods for efficient re-use.
+    """
+
+    def __init__(self, cloud_path: "CloudPath") -> None:
+        self.cloud_path: "CloudPath" = cloud_path
+
+    @lru_cache
+    def exists(self, *, follow_symlinks: bool = True) -> bool:
+        return self.cloud_path.exists()
+
+    @lru_cache
+    def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+        return self.cloud_path.is_dir(follow_symlinks=follow_symlinks)
+
+    @lru_cache
+    def is_file(self, *, follow_symlinks: bool = True) -> bool:
+        return self.cloud_path.is_file(follow_symlinks=follow_symlinks)
+
+    def is_symlink(self) -> bool:
+        return False

--- a/cloudpathlib/gs/gspath.py
+++ b/cloudpathlib/gs/gspath.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Optional
+from typing import Any, TYPE_CHECKING, Optional
 
 from ..cloudpath import CloudPath, NoStatError, register_path_class
 
@@ -32,11 +32,11 @@ class GSPath(CloudPath):
     def drive(self) -> str:
         return self.bucket
 
-    def mkdir(self, parents=False, exist_ok=False):
+    def mkdir(self, parents=False, exist_ok=False, mode: Optional[Any] = None):
         # not possible to make empty directory on cloud storage
         pass
 
-    def touch(self, exist_ok: bool = True):
+    def touch(self, exist_ok: bool = True, mode: Optional[Any] = None):
         if self.exists():
             if not exist_ok:
                 raise FileExistsError(f"File exists: {self}")
@@ -50,7 +50,7 @@ class GSPath(CloudPath):
 
             tf.cleanup()
 
-    def stat(self):
+    def stat(self, follow_symlinks=True):
         meta = self.client._get_metadata(self)
         if meta is None:
             raise NoStatError(

--- a/cloudpathlib/http/httppath.py
+++ b/cloudpathlib/http/httppath.py
@@ -80,10 +80,12 @@ class HttpPath(CloudPath):
 
         return not self.client.dir_matcher(str(self))
 
-    def mkdir(self, parents: bool = False, exist_ok: bool = False) -> None:
+    def mkdir(
+        self, parents: bool = False, exist_ok: bool = False, mode: Optional[Any] = None
+    ) -> None:
         pass  # no-op for HTTP Paths
 
-    def touch(self, exist_ok: bool = True) -> None:
+    def touch(self, exist_ok: bool = True, mode: Optional[Any] = None) -> None:
         if self.exists():
             if not exist_ok:
                 raise FileExistsError(f"File already exists: {self}")

--- a/cloudpathlib/local/implementations/azure.py
+++ b/cloudpathlib/local/implementations/azure.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Optional
 
 from ...cloudpath import CloudImplementation
 from ...exceptions import MissingCredentialsError
@@ -49,7 +50,7 @@ class LocalAzureBlobPath(LocalPath):
     def drive(self) -> str:
         return self.container
 
-    def mkdir(self, parents=False, exist_ok=False):
+    def mkdir(self, parents=False, exist_ok=False, mode: Optional[Any] = None):
         # not possible to make empty directory on blob storage
         pass
 

--- a/cloudpathlib/local/implementations/gs.py
+++ b/cloudpathlib/local/implementations/gs.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional
+
 from ...cloudpath import CloudImplementation
 from ..localclient import LocalClient
 from ..localpath import LocalPath
@@ -30,7 +32,7 @@ class LocalGSPath(LocalPath):
     def drive(self) -> str:
         return self.bucket
 
-    def mkdir(self, parents=False, exist_ok=False):
+    def mkdir(self, parents=False, exist_ok=False, mode: Optional[Any] = None):
         # not possible to make empty directory on gs
         pass
 

--- a/cloudpathlib/local/implementations/s3.py
+++ b/cloudpathlib/local/implementations/s3.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional
+
 from ...cloudpath import CloudImplementation
 from ..localclient import LocalClient
 from ..localpath import LocalPath
@@ -30,7 +32,7 @@ class LocalS3Path(LocalPath):
     def drive(self) -> str:
         return self.bucket
 
-    def mkdir(self, parents=False, exist_ok=False):
+    def mkdir(self, parents=False, exist_ok=False, mode: Optional[Any] = None):
         # not possible to make empty directory on s3
         pass
 

--- a/cloudpathlib/local/localpath.py
+++ b/cloudpathlib/local/localpath.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from ..cloudpath import CloudPath, NoStatError
 
@@ -19,7 +19,7 @@ class LocalPath(CloudPath):
     def is_file(self, follow_symlinks=True) -> bool:
         return self.client._is_file(self, follow_symlinks=follow_symlinks)
 
-    def stat(self):
+    def stat(self, follow_symlinks=True):
         try:
             meta = self.client._stat(self)
         except FileNotFoundError:
@@ -28,5 +28,5 @@ class LocalPath(CloudPath):
             )
         return meta
 
-    def touch(self, exist_ok: bool = True):
+    def touch(self, exist_ok: bool = True, mode: Optional[Any] = None):
         self.client._touch(self, exist_ok)

--- a/cloudpathlib/s3/s3path.py
+++ b/cloudpathlib/s3/s3path.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from ..cloudpath import CloudPath, NoStatError, register_path_class
 
@@ -32,11 +32,11 @@ class S3Path(CloudPath):
     def drive(self) -> str:
         return self.bucket
 
-    def mkdir(self, parents=False, exist_ok=False):
+    def mkdir(self, parents=False, exist_ok=False, mode: Optional[Any] = None):
         # not possible to make empty directory on s3
         pass
 
-    def touch(self, exist_ok: bool = True):
+    def touch(self, exist_ok: bool = True, mode: Optional[Any] = None):
         if self.exists():
             if not exist_ok:
                 raise FileExistsError(f"File exists: {self}")
@@ -50,7 +50,7 @@ class S3Path(CloudPath):
 
             tf.cleanup()
 
-    def stat(self):
+    def stat(self, follow_symlinks=True):
         try:
             meta = self.client._get_metadata(self)
         except self.client.client.exceptions.NoSuchKey:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "cloudpathlib"
-version = "0.22.0"
+version = "0.23.0"
 description = "pathlib-style classes for cloud storage services."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }]
@@ -31,7 +31,6 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "typing-extensions>4 ; python_version < '3.11'",
-  "pathlib-abc < 0.6 ; python_version < '3.14'",
 ]
 
 [project.optional-dependencies]
@@ -50,7 +49,7 @@ all = ["cloudpathlib[azure]", "cloudpathlib[gs]", "cloudpathlib[s3]"]
 
 [tool.black]
 line-length = 99
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313', 'py314']
 include = '\.pyi?$|\.ipynb$'
 extend-exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "typing-extensions>4 ; python_version < '3.11'",
+  "pathlib-abc ; python_version < '3.14'",
 ]
 
 [project.optional-dependencies]
@@ -49,7 +50,7 @@ all = ["cloudpathlib[azure]", "cloudpathlib[gs]", "cloudpathlib[s3]"]
 
 [tool.black]
 line-length = 99
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$|\.ipynb$'
 extend-exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "typing-extensions>4 ; python_version < '3.11'",
-  "pathlib-abc ; python_version < '3.14'",
+  "pathlib-abc < 0.6 ; python_version < '3.14'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -291,22 +291,23 @@ def test_info(rig):
     """Test the info() method returns a CloudPathInfo object."""
     p = rig.create_cloud_path("dir_0/file0_0.txt")
     info = p.info()
-    
+
     # Check that info() returns a CloudPathInfo object
     from cloudpathlib.cloudpath_info import CloudPathInfo
+
     assert isinstance(info, CloudPathInfo)
-    
+
     # Check that the info object has the expected methods
-    assert hasattr(info, 'exists')
-    assert hasattr(info, 'is_dir')
-    assert hasattr(info, 'is_file')
-    assert hasattr(info, 'is_symlink')
-    
+    assert hasattr(info, "exists")
+    assert hasattr(info, "is_dir")
+    assert hasattr(info, "is_file")
+    assert hasattr(info, "is_symlink")
+
     # Test that the info object works correctly
     assert info.exists() == p.exists()
     assert info.is_file() == p.is_file()
     assert info.is_dir() == p.is_dir()
-    assert info.is_symlink() == False  # Cloud paths are never symlinks
+    assert info.is_symlink() is False  # Cloud paths are never symlinks
 
 
 def test_copy_into(rig, tmpdir):
@@ -314,29 +315,29 @@ def test_copy_into(rig, tmpdir):
     # Create a test file
     p = rig.create_cloud_path("test_file.txt")
     p.write_text("Hello from copy_into")
-    
+
     # Test copying into a local directory
     local_dir = Path(tmpdir.mkdir("copy_into_local"))
     result = p.copy_into(local_dir)
-    
+
     assert isinstance(result, Path)
     assert result.exists()
     assert result.name == "test_file.txt"
     assert result.read_text() == "Hello from copy_into"
-    
+
     # Test copying into a cloud directory
     cloud_dir = rig.create_cloud_path("copy_into_cloud/")
     cloud_dir.mkdir()
     result = p.copy_into(cloud_dir)
-    
+
     assert result.exists()
     assert str(result) == str(cloud_dir / "test_file.txt")
     assert result.read_text() == "Hello from copy_into"
-    
+
     # Test copying into a string path
     local_dir2 = Path(tmpdir.mkdir("copy_into_str"))
     result = p.copy_into(str(local_dir2))
-    
+
     assert result.exists()
     assert result.name == "test_file.txt"
     assert result.read_text() == "Hello from copy_into"
@@ -347,34 +348,34 @@ def test_move(rig, tmpdir):
     # Create a test file
     p = rig.create_cloud_path("test_move_file.txt")
     p.write_text("Hello from move")
-    
+
     # Test moving to a local file
     local_file = Path(tmpdir) / "moved_file.txt"
     result = p.move(local_file)
-    
+
     assert isinstance(result, Path)
     assert result.exists()
     assert result.read_text() == "Hello from move"
     # Note: When moving cloud->local, the source may still exist due to download_to behavior
-    
+
     # Test moving to a cloud location (same client)
     p2 = rig.create_cloud_path("test_move_file2.txt")
     p2.write_text("Hello from move 2")
-    
+
     cloud_dest = rig.create_cloud_path("moved_cloud_file.txt")
     result = p2.move(cloud_dest)
-    
+
     assert result.exists()
     assert result.read_text() == "Hello from move 2"
     assert not p2.exists()  # Original should be gone for cloud->cloud moves
-    
+
     # Test moving to a string path
     p3 = rig.create_cloud_path("test_move_file3.txt")
     p3.write_text("Hello from move 3")
-    
+
     local_file2 = Path(tmpdir) / "moved_file3.txt"
     result = p3.move(str(local_file2))
-    
+
     assert result.exists()
     assert result.read_text() == "Hello from move 3"
     # Note: When moving cloud->local, the source may still exist due to download_to behavior
@@ -385,37 +386,37 @@ def test_move_into(rig, tmpdir):
     # Create a test file
     p = rig.create_cloud_path("test_move_into_file.txt")
     p.write_text("Hello from move_into")
-    
+
     # Test moving into a local directory
     local_dir = Path(tmpdir.mkdir("move_into_local"))
     result = p.move_into(local_dir)
-    
+
     assert isinstance(result, Path)
     assert result.exists()
     assert result.name == "test_move_into_file.txt"
     assert result.read_text() == "Hello from move_into"
     # Note: When moving cloud->local, the source may still exist due to download_to behavior
-    
+
     # Test moving into a cloud directory
     p2 = rig.create_cloud_path("test_move_into_file2.txt")
     p2.write_text("Hello from move_into 2")
-    
+
     cloud_dir = rig.create_cloud_path("move_into_cloud/")
     cloud_dir.mkdir()
     result = p2.move_into(cloud_dir)
-    
+
     assert result.exists()
     assert str(result) == str(cloud_dir / "test_move_into_file2.txt")
     assert result.read_text() == "Hello from move_into 2"
     assert not p2.exists()  # Original should be gone for cloud->cloud moves
-    
+
     # Test moving into a string path
     p3 = rig.create_cloud_path("test_move_into_file3.txt")
     p3.write_text("Hello from move_into 3")
-    
+
     local_dir2 = Path(tmpdir.mkdir("move_into_str"))
     result = p3.move_into(str(local_dir2))
-    
+
     assert result.exists()
     assert result.name == "test_move_into_file3.txt"
     assert result.read_text() == "Hello from move_into 3"

--- a/tests/test_cloudpath_upload_copy.py
+++ b/tests/test_cloudpath_upload_copy.py
@@ -285,3 +285,138 @@ def test_copytree(rig, tmpdir):
     assert not (p4 / "ignored.py").exists()
     assert not (p4 / "dir1").exists()
     assert not (p4 / "dir2").exists()
+
+
+def test_info(rig):
+    """Test the info() method returns a CloudPathInfo object."""
+    p = rig.create_cloud_path("dir_0/file0_0.txt")
+    info = p.info()
+    
+    # Check that info() returns a CloudPathInfo object
+    from cloudpathlib.cloudpath_info import CloudPathInfo
+    assert isinstance(info, CloudPathInfo)
+    
+    # Check that the info object has the expected methods
+    assert hasattr(info, 'exists')
+    assert hasattr(info, 'is_dir')
+    assert hasattr(info, 'is_file')
+    assert hasattr(info, 'is_symlink')
+    
+    # Test that the info object works correctly
+    assert info.exists() == p.exists()
+    assert info.is_file() == p.is_file()
+    assert info.is_dir() == p.is_dir()
+    assert info.is_symlink() == False  # Cloud paths are never symlinks
+
+
+def test_copy_into(rig, tmpdir):
+    """Test the copy_into() method."""
+    # Create a test file
+    p = rig.create_cloud_path("test_file.txt")
+    p.write_text("Hello from copy_into")
+    
+    # Test copying into a local directory
+    local_dir = Path(tmpdir.mkdir("copy_into_local"))
+    result = p.copy_into(local_dir)
+    
+    assert isinstance(result, Path)
+    assert result.exists()
+    assert result.name == "test_file.txt"
+    assert result.read_text() == "Hello from copy_into"
+    
+    # Test copying into a cloud directory
+    cloud_dir = rig.create_cloud_path("copy_into_cloud/")
+    cloud_dir.mkdir()
+    result = p.copy_into(cloud_dir)
+    
+    assert result.exists()
+    assert str(result) == str(cloud_dir / "test_file.txt")
+    assert result.read_text() == "Hello from copy_into"
+    
+    # Test copying into a string path
+    local_dir2 = Path(tmpdir.mkdir("copy_into_str"))
+    result = p.copy_into(str(local_dir2))
+    
+    assert result.exists()
+    assert result.name == "test_file.txt"
+    assert result.read_text() == "Hello from copy_into"
+
+
+def test_move(rig, tmpdir):
+    """Test the move() method."""
+    # Create a test file
+    p = rig.create_cloud_path("test_move_file.txt")
+    p.write_text("Hello from move")
+    
+    # Test moving to a local file
+    local_file = Path(tmpdir) / "moved_file.txt"
+    result = p.move(local_file)
+    
+    assert isinstance(result, Path)
+    assert result.exists()
+    assert result.read_text() == "Hello from move"
+    # Note: When moving cloud->local, the source may still exist due to download_to behavior
+    
+    # Test moving to a cloud location (same client)
+    p2 = rig.create_cloud_path("test_move_file2.txt")
+    p2.write_text("Hello from move 2")
+    
+    cloud_dest = rig.create_cloud_path("moved_cloud_file.txt")
+    result = p2.move(cloud_dest)
+    
+    assert result.exists()
+    assert result.read_text() == "Hello from move 2"
+    assert not p2.exists()  # Original should be gone for cloud->cloud moves
+    
+    # Test moving to a string path
+    p3 = rig.create_cloud_path("test_move_file3.txt")
+    p3.write_text("Hello from move 3")
+    
+    local_file2 = Path(tmpdir) / "moved_file3.txt"
+    result = p3.move(str(local_file2))
+    
+    assert result.exists()
+    assert result.read_text() == "Hello from move 3"
+    # Note: When moving cloud->local, the source may still exist due to download_to behavior
+
+
+def test_move_into(rig, tmpdir):
+    """Test the move_into() method."""
+    # Create a test file
+    p = rig.create_cloud_path("test_move_into_file.txt")
+    p.write_text("Hello from move_into")
+    
+    # Test moving into a local directory
+    local_dir = Path(tmpdir.mkdir("move_into_local"))
+    result = p.move_into(local_dir)
+    
+    assert isinstance(result, Path)
+    assert result.exists()
+    assert result.name == "test_move_into_file.txt"
+    assert result.read_text() == "Hello from move_into"
+    # Note: When moving cloud->local, the source may still exist due to download_to behavior
+    
+    # Test moving into a cloud directory
+    p2 = rig.create_cloud_path("test_move_into_file2.txt")
+    p2.write_text("Hello from move_into 2")
+    
+    cloud_dir = rig.create_cloud_path("move_into_cloud/")
+    cloud_dir.mkdir()
+    result = p2.move_into(cloud_dir)
+    
+    assert result.exists()
+    assert str(result) == str(cloud_dir / "test_move_into_file2.txt")
+    assert result.read_text() == "Hello from move_into 2"
+    assert not p2.exists()  # Original should be gone for cloud->cloud moves
+    
+    # Test moving into a string path
+    p3 = rig.create_cloud_path("test_move_into_file3.txt")
+    p3.write_text("Hello from move_into 3")
+    
+    local_dir2 = Path(tmpdir.mkdir("move_into_str"))
+    result = p3.move_into(str(local_dir2))
+    
+    assert result.exists()
+    assert result.name == "test_move_into_file3.txt"
+    assert result.read_text() == "Hello from move_into 3"
+    # Note: When moving cloud->local, the source may still exist due to download_to behavior


### PR DESCRIPTION
Support for 3.14.

All the tests pass locally on 3.14rc2 except the pydantic integration test since there isn't a pydantic release compatible with 3.14 yet.  The test does pass with the prerelease (see https://github.com/pydantic/pydantic/issues/11613) with 3.14 support.

Release schedule for 3.14 is:

- 3.14.0 candidate 3: Tuesday, 2025-09-16
- 3.14.0 final: Tuesday, 2025-10-07

This will need to wait until 3.14 is supported in CI as well.

Here is what is still needed to match the [`pathlib` changes in 3.14](https://docs.python.org/3.14/whatsnew/3.14.html#pathlib):

 - [x] Change `copy` for args/kwargs to match
 - [x] Add `copy_into`
 - [x] Add `move`
 - [x] Add `move_into`
 - [x] Add `.info` that implements `PathInfo`
 - [x] Confirm everything passes once 3.14 is supported in CI
 - [x] Update single version CI tasks from 3.11 to 3.12
 - [x] Bonus: move to `setup-uv` action (was needed for 3.14 to work)
 - [x] Remove `--pre` flag from `tests.yml` once pydantic 3.14 support is released ([see >= 2.12](https://pypi.org/project/pydantic/#history))
 - [x] Add py314 to black target version when black supports it
 - [x] See about `pathlib-abc` as a backport or if we should vendor the protocol code https://github.com/barneygale/pathlib-abc/issues/45


Closes #529 

