### PR TITLE
Lazy load

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 - Added support for Pydantic serialization (Issue [#537](https://github.com/drivendataorg/cloudpathlib/issues/537), PR [#538](https://github.com/drivendataorg/cloudpathlib/pull/538))
+- Improved import time by lazy-loading cloud provider modules (Issue [#544](https://github.com/drivendataorg/cloudpathlib/issues/544), PR [#TBD](https://github.com/drivendataorg/cloudpathlib/pull/TBD))
 
 ## v0.23.0 (2025-10-07)
 

--- a/cloudpathlib/__init__.py
+++ b/cloudpathlib/__init__.py
@@ -1,17 +1,30 @@
 import os
 import sys
+from typing import TYPE_CHECKING
 
-from .anypath import AnyPath
-from .azure.azblobclient import AzureBlobClient
-from .azure.azblobpath import AzureBlobPath
-from .cloudpath import CloudPath, implementation_registry
-from .patches import patch_open, patch_os_functions, patch_glob, patch_all_builtins
-from .gs.gsclient import GSClient
-from .gs.gspath import GSPath
-from .http.httpclient import HttpClient, HttpsClient
-from .http.httppath import HttpPath, HttpsPath
-from .s3.s3client import S3Client
-from .s3.s3path import S3Path
+# Lazy imports for cloud providers to avoid loading heavy SDKs at import time
+# Google Cloud SDK alone adds ~200ms to import time
+
+if TYPE_CHECKING:
+    from .anypath import AnyPath as AnyPath
+    from .azure.azblobclient import AzureBlobClient as AzureBlobClient
+    from .azure.azblobpath import AzureBlobPath as AzureBlobPath
+    from .cloudpath import (
+        CloudPath as CloudPath,
+        implementation_registry as implementation_registry,
+    )
+    from .patches import (
+        patch_open as patch_open,
+        patch_os_functions as patch_os_functions,
+        patch_glob as patch_glob,
+        patch_all_builtins as patch_all_builtins,
+    )
+    from .gs.gsclient import GSClient as GSClient
+    from .gs.gspath import GSPath as GSPath
+    from .http.httpclient import HttpClient as HttpClient, HttpsClient as HttpsClient
+    from .http.httppath import HttpPath as HttpPath, HttpsPath as HttpsPath
+    from .s3.s3client import S3Client as S3Client
+    from .s3.s3path import S3Path as S3Path
 
 if sys.version_info[:2] >= (3, 8):
     import importlib.metadata as importlib_metadata
@@ -43,14 +56,66 @@ __all__ = [
 ]
 
 
+# Lazy loading implementation
+_LAZY_IMPORTS = {
+    # Core
+    "AnyPath": ".anypath",
+    "CloudPath": ".cloudpath",
+    "implementation_registry": ".cloudpath",
+    # Patches
+    "patch_open": ".patches",
+    "patch_os_functions": ".patches",
+    "patch_glob": ".patches",
+    "patch_all_builtins": ".patches",
+    # S3
+    "S3Client": ".s3.s3client",
+    "S3Path": ".s3.s3path",
+    # GCS
+    "GSClient": ".gs.gsclient",
+    "GSPath": ".gs.gspath",
+    # Azure
+    "AzureBlobClient": ".azure.azblobclient",
+    "AzureBlobPath": ".azure.azblobpath",
+    # HTTP
+    "HttpClient": ".http.httpclient",
+    "HttpsClient": ".http.httpclient",
+    "HttpPath": ".http.httppath",
+    "HttpsPath": ".http.httppath",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path, __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return __all__
+
+
+# Handle environment-variable-based patching
+# These need to be checked at import time, so we do them lazily only if env vars are set
 if bool(os.environ.get("CLOUDPATHLIB_PATCH_OPEN", "")):
-    patch_open()
+    from .patches import patch_open as _patch_open
+
+    _patch_open()
 
 if bool(os.environ.get("CLOUDPATHLIB_PATCH_OS", "")):
-    patch_os_functions()
+    from .patches import patch_os_functions as _patch_os_functions
+
+    _patch_os_functions()
 
 if bool(os.environ.get("CLOUDPATHLIB_PATCH_GLOB", "")):
-    patch_glob()
+    from .patches import patch_glob as _patch_glob
+
+    _patch_glob()
 
 if bool(os.environ.get("CLOUDPATHLIB_PATCH_ALL", "")):
-    patch_all_builtins()
+    from .patches import patch_all_builtins as _patch_all_builtins
+
+    _patch_all_builtins()

--- a/cloudpathlib/azure/__init__.py
+++ b/cloudpathlib/azure/__init__.py
@@ -1,7 +1,22 @@
-from .azblobclient import AzureBlobClient
-from .azblobpath import AzureBlobPath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .azblobclient import AzureBlobClient as AzureBlobClient
+    from .azblobpath import AzureBlobPath as AzureBlobPath
 
 __all__ = [
     "AzureBlobClient",
     "AzureBlobPath",
 ]
+
+
+def __getattr__(name: str):
+    if name == "AzureBlobClient":
+        from .azblobclient import AzureBlobClient
+
+        return AzureBlobClient
+    if name == "AzureBlobPath":
+        from .azblobpath import AzureBlobPath
+
+        return AzureBlobPath
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -80,9 +80,8 @@ elif sys.version_info >= (3, 14):
     from .legacy.glob import _make_selector  # noqa: F811
 
 
-from cloudpathlib.enums import FileCacheMode
+from .enums import FileCacheMode
 
-from . import anypath
 from .exceptions import (
     ClientMismatchError,
     CloudPathFileExistsError,
@@ -1143,6 +1142,8 @@ class CloudPath(metaclass=CloudPathMeta):
         force_overwrite_to_cloud: Optional[bool] = None,
         remove_src: bool = False,
     ) -> Union[Path, Self]:
+        from . import anypath
+
         if not self.exists():
             raise ValueError(f"Path {self} must exist to copy.")
 
@@ -1275,6 +1276,8 @@ class CloudPath(metaclass=CloudPathMeta):
         force_overwrite_to_cloud: Optional[bool] = None,
     ) -> Union[Path, Self]:
         """Copy self into target directory, preserving the filename."""
+        from . import anypath
+
         target_path = anypath.to_anypath(target_dir) / self.name
 
         result = self._copy(
@@ -1312,6 +1315,8 @@ class CloudPath(metaclass=CloudPathMeta):
 
     def copytree(self, destination, force_overwrite_to_cloud=None, ignore=None):
         """Copy self to a directory, if self is a directory."""
+        from . import anypath
+
         if not self.is_dir():
             raise CloudPathNotADirectoryError(
                 f"Origin path {self} must be a directory. To copy a single file use the method copy."
@@ -1427,6 +1432,8 @@ class CloudPath(metaclass=CloudPathMeta):
         force_overwrite_to_cloud: Optional[bool] = None,
     ) -> Union[Path, Self]:
         """Move self into target directory, preserving the filename and removing the source."""
+        from . import anypath
+
         target_path = anypath.to_anypath(target_dir) / self.name
 
         result = self._copy(

--- a/cloudpathlib/gs/__init__.py
+++ b/cloudpathlib/gs/__init__.py
@@ -1,7 +1,22 @@
-from .gsclient import GSClient
-from .gspath import GSPath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .gsclient import GSClient as GSClient
+    from .gspath import GSPath as GSPath
 
 __all__ = [
     "GSClient",
     "GSPath",
 ]
+
+
+def __getattr__(name: str):
+    if name == "GSClient":
+        from .gsclient import GSClient
+
+        return GSClient
+    if name == "GSPath":
+        from .gspath import GSPath
+
+        return GSPath
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/cloudpathlib/s3/__init__.py
+++ b/cloudpathlib/s3/__init__.py
@@ -1,7 +1,22 @@
-from .s3client import S3Client
-from .s3path import S3Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .s3client import S3Client as S3Client
+    from .s3path import S3Path as S3Path
 
 __all__ = [
     "S3Client",
     "S3Path",
 ]
+
+
+def __getattr__(name: str):
+    if name == "S3Client":
+        from .s3client import S3Client
+
+        return S3Client
+    if name == "S3Path":
+        from .s3path import S3Path
+
+        return S3Path
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -1,0 +1,262 @@
+"""Test that importing cloudpathlib doesn't eagerly load cloud provider SDKs.
+
+These tests verify that lazy loading is working correctly by checking that
+heavy cloud SDK modules are not loaded until actually needed.
+"""
+
+import subprocess
+import sys
+
+
+def test_import_does_not_load_cloud_sdks():
+    """Verify that importing cloudpathlib doesn't eagerly load cloud provider SDKs.
+
+    Cloud SDKs (google-cloud-storage, boto3, azure-storage-blob) are heavy and
+    add significant import time. They should only be loaded when actually used.
+    """
+    # Run a subprocess to get a clean import state
+    code = """
+import sys
+
+# Import cloudpathlib
+import cloudpathlib
+
+# Check that cloud SDKs are NOT loaded yet
+cloud_sdk_modules = [
+    'google.cloud.storage',
+    'google.api_core',
+    'boto3',
+    'botocore',
+    'azure.storage.blob',
+]
+
+loaded = [m for m in cloud_sdk_modules if m in sys.modules]
+if loaded:
+    print(f"FAIL: These modules were eagerly loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: No cloud SDK modules were eagerly loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_accessing_path_class_does_not_load_other_sdks():
+    """Verify that accessing one Path class doesn't load other provider SDKs.
+
+    When you access S3Path, it shouldn't load GCS or Azure SDKs.
+    """
+    code = """
+import sys
+
+# Access S3Path class (but don't instantiate)
+from cloudpathlib import S3Path
+
+# GCS and Azure should NOT be loaded just from accessing S3Path
+other_sdks = [
+    'google.cloud.storage',
+    'google.api_core',
+    'azure.storage.blob',
+]
+
+loaded = [m for m in other_sdks if m in sys.modules]
+if loaded:
+    print(f"FAIL: These unrelated modules were loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: Other provider SDKs were not loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_accessing_gs_path_class_does_not_load_other_sdks():
+    """Verify that accessing GSPath class doesn't load S3 or Azure SDKs."""
+    code = """
+import sys
+
+# Access GSPath class (but don't instantiate)
+from cloudpathlib import GSPath
+
+# S3 and Azure should NOT be loaded
+other_sdks = [
+    'boto3',
+    'botocore',
+    'azure.storage.blob',
+]
+
+loaded = [m for m in other_sdks if m in sys.modules]
+if loaded:
+    print(f"FAIL: These unrelated modules were loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: Other provider SDKs were not loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_accessing_azure_path_class_does_not_load_other_sdks():
+    """Verify that accessing AzureBlobPath class doesn't load S3 or GCS SDKs."""
+    code = """
+import sys
+
+# Access AzureBlobPath class (but don't instantiate)
+from cloudpathlib import AzureBlobPath
+
+# S3 and GCS should NOT be loaded
+other_sdks = [
+    'boto3',
+    'botocore',
+    'google.cloud.storage',
+    'google.api_core',
+]
+
+loaded = [m for m in other_sdks if m in sys.modules]
+if loaded:
+    print(f"FAIL: These unrelated modules were loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: Other provider SDKs were not loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_submodule_import_s3_does_not_load_other_sdks():
+    """Verify that importing from cloudpathlib.s3 doesn't load other SDKs."""
+    code = """
+import sys
+
+# Import from submodule directly
+from cloudpathlib.s3 import S3Path
+
+# GCS and Azure should NOT be loaded
+other_sdks = [
+    'google.cloud.storage',
+    'google.api_core',
+    'azure.storage.blob',
+]
+
+loaded = [m for m in other_sdks if m in sys.modules]
+if loaded:
+    print(f"FAIL: These unrelated modules were loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: Other provider SDKs were not loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_submodule_import_gs_does_not_load_other_sdks():
+    """Verify that importing from cloudpathlib.gs doesn't load other SDKs."""
+    code = """
+import sys
+
+# Import from submodule directly
+from cloudpathlib.gs import GSPath
+
+# S3 and Azure should NOT be loaded
+other_sdks = [
+    'boto3',
+    'botocore',
+    'azure.storage.blob',
+]
+
+loaded = [m for m in other_sdks if m in sys.modules]
+if loaded:
+    print(f"FAIL: These unrelated modules were loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: Other provider SDKs were not loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_submodule_import_azure_does_not_load_other_sdks():
+    """Verify that importing from cloudpathlib.azure doesn't load other SDKs."""
+    code = """
+import sys
+
+# Import from submodule directly
+from cloudpathlib.azure import AzureBlobPath
+
+# S3 and GCS should NOT be loaded
+other_sdks = [
+    'boto3',
+    'botocore',
+    'google.cloud.storage',
+    'google.api_core',
+]
+
+loaded = [m for m in other_sdks if m in sys.modules]
+if loaded:
+    print(f"FAIL: These unrelated modules were loaded: {loaded}")
+    sys.exit(1)
+else:
+    print("PASS: Other provider SDKs were not loaded")
+    sys.exit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Test failed: {result.stdout}\n{result.stderr}"
+
+
+def test_import_time_reasonable():
+    """Verify that importing cloudpathlib takes less than 500ms.
+
+    Before lazy loading, importing cloudpathlib would load all cloud SDKs,
+    taking 1-2 seconds. With lazy loading, it should be under 500ms.
+    """
+    code = """
+import time
+start = time.perf_counter()
+import cloudpathlib
+elapsed = time.perf_counter() - start
+print(f"{elapsed:.3f}")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Import failed: {result.stderr}"
+
+    elapsed = float(result.stdout.strip())
+    # Allow up to 500ms for import (generous for CI environments)
+    assert elapsed < 0.5, f"Import took {elapsed:.3f}s, expected < 0.5s"


### PR DESCRIPTION
Implement lazy loading to speed up import times for packages that use this library

Closes #544 

## Title
Improve import time by lazy-loading cloud provider modules

## Description

### Problem

Importing `cloudpathlib` currently takes **~435ms** because it eagerly loads all cloud provider SDKs (`google-cloud-storage`, `boto3`, `azure-storage-blob`) at import time, even if the user only needs one provider.

This is problematic for:
- **CLI tools** where startup latency matters
- **Serverless functions** where cold start time is critical
- **Applications** that only use one cloud provider but pay the import cost for all three

### Benchmarks

Measured with Python 3.12 (5 runs, mean ± std):

| Scenario | Current | With Lazy Loading | Improvement |
|----------|---------|-------------------|-------------|
| `import cloudpathlib` | 435ms ± 24ms | 22ms ± 1ms | **20x faster** |
| `from cloudpathlib import S3Path` | 410ms ± 3ms | 23ms ± 0ms | **18x faster** |
| `from cloudpathlib import GSPath` | 410ms ± 3ms | 24ms ± 1ms | **17x faster** |
| `from cloudpathlib import AzureBlobPath` | 413ms ± 7ms | 41ms ± 1ms | **10x faster** |

Additionally, the current implementation loads **all three SDKs** even when importing just one path class. With lazy loading, only the SDK for the provider being used gets loaded.

### Proposed Solution

Implement lazy loading via `__getattr__` in the `__init__.py` files:
- `cloudpathlib/__init__.py`
- `cloudpathlib/s3/__init__.py`
- `cloudpathlib/gs/__init__.py`
- `cloudpathlib/azure/__init__.py`

This defers loading cloud SDKs until they are actually accessed, while preserving static type hints via `TYPE_CHECKING` blocks.

### Example

**Before:**
import cloudpathlib  # Takes ~435ms, loads all SDKs**After:**
import cloudpathlib  # Takes ~22ms, no SDKs loaded
from cloudpathlib import S3Path  # Only loads boto3 when S3Path is accessed

### Implementation Notes

- Use `__getattr__` with `TYPE_CHECKING` blocks for static type hints (IDE support preserved)
- Fix absolute import in `cloudpath.py` (`from cloudpathlib.enums` → `from .enums`)
- Move `anypath` import to function-local in `cloudpath.py` to avoid circular imports
- Add tests to verify lazy loading behavior and prevent regressions

----------------

Contributor checklist:

 - [x] I have read and understood `CONTRIBUTING.md`
 - [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary (e.g., `Closes #123`).
 - [x] Confirmed PR is rebased onto the latest base
 - [x] Confirmed failure before change and success after change
 - [x] Any generic new functionality is replicated across cloud providers if necessary
 - [x] Tested manually against live server backend for at least one provider
 - [x] Added tests for any new functionality
 - [x] Linting passes locally
 - [x] Tests pass locally
 - [x] Updated `HISTORY.md` with the issue that is addressed and the PR you are submitting. If the top section is not `## UNRELEASED``, then you need to add a new section to the top of the document for your change.