### PR TITLE
Fix local cache not cleared after mutating operations

### DIFF
--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -799,6 +799,8 @@ class CloudPath(metaclass=CloudPathMeta):
             target.unlink()
 
         self.client._move_file(self, target)
+        self.clear_cache()
+        target.clear_cache()
         return target
 
     def rename(self, target: Self) -> Self:
@@ -819,6 +821,7 @@ class CloudPath(metaclass=CloudPathMeta):
         except StopIteration:
             pass
         self.client._remove(self)
+        self.clear_cache()
 
     def samefile(self, other_path: Union[str, os.PathLike]) -> bool:
         # all cloud paths are absolute and the paths are used for hash
@@ -831,6 +834,7 @@ class CloudPath(metaclass=CloudPathMeta):
                 f"Path {self} is a directory; call rmdir instead of unlink."
             )
         self.client._remove(self, missing_ok)
+        self.clear_cache()
 
     def write_bytes(self, data: bytes) -> int:
         """Open the file in bytes mode, write to it, and close the file.
@@ -1110,6 +1114,7 @@ class CloudPath(metaclass=CloudPathMeta):
                 f"Path {self} is a file; call unlink instead of rmtree."
             )
         self.client._remove(self)
+        self.clear_cache()
 
     def upload_from(
         self,

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -18,6 +18,7 @@ from cloudpathlib.exceptions import (
     OverwriteNewerCloudError,
     OverwriteNewerLocalError,
 )
+from cloudpathlib.http.httppath import HttpPath, HttpsPath
 from tests.conftest import CloudProviderTestRig
 from tests.utils import _sync_filesystem
 
@@ -540,3 +541,39 @@ def test_reuse_cache_after_manual_cache_clear(rig: CloudProviderTestRig):
         _ = f.read()
 
     assert cp._local.exists()
+
+def test_cache_cleared_after_mutation(rig: CloudProviderTestRig):
+    # --- unlink ---
+    client = rig.client_class(**rig.required_client_kwargs)
+    cp = rig.create_cloud_path("dir_0/file0_0.txt", client=client)
+    with cp.open("r") as f:
+        _ = f.read()
+    assert cp._local.exists()
+    cp.unlink()
+    assert not cp._local.exists()
+
+    # --- replace ---
+    client2 = rig.client_class(**rig.required_client_kwargs)
+    src = rig.create_cloud_path("dir_0/file0_1.txt", client=client2)
+    dst = rig.create_cloud_path("dir_0/file0_2.txt", client=client2)
+    # read both to populate cache, then replace, then assert both caches cleared
+    with src.open("r") as f:
+        _ = f.read()
+    with dst.open("r") as f:
+        _ = f.read()
+    assert src._local.exists()
+    assert dst._local.exists()
+    dst.replace(src)
+    assert not src._local.exists()
+    assert not dst._local.exists()
+
+    # --- rmtree ---
+    if rig.path_class not in [HttpPath, HttpsPath]:
+        client3 = rig.client_class(**rig.required_client_kwargs)
+        dp = rig.create_cloud_path("dir_0", client=client3)
+        _ = rig.create_cloud_path("dir_0/file0_1.txt", client=client3)
+        with _.open("r") as f:
+            _ = f.read()
+        assert dp._local.exists()
+        dp.rmtree()
+        assert not dp._local.exists()


### PR DESCRIPTION
## Summary

Fixes #388.

When files or directories are deleted or moved via `unlink`, `replace`, `rename`, `rmdir`, or `rmtree`, the local cache was not being cleared. This caused stale cached files to persist on disk, leading to errors or incorrect data on subsequent access.

- Added `self.clear_cache()` after `_remove` in `unlink` and `rmdir`
- Added `self.clear_cache()` and `target.clear_cache()` after `_move_file` in `replace` (`rename` delegates to `replace` and gets the fix for free)
- Added `self.clear_cache()` after `_remove` in `rmtree`

**Note:** `rmdir` on Azure and S3 may behave unexpectedly with empty directories since those providers don't persist empty directory objects. This is a pre-existing limitation unrelated to this fix.

## Test plan

- [x] Added `test_cache_cleared_after_mutation` to `tests/test_caching.py` covering `unlink`, `replace`, and `rmtree` across all supported providers
- [x] All 140 caching tests pass
- [x] All file I/O and manipulation tests pass