### PR TITLE
Fix mypy 2.x type errors in client and cloudpath modules

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cloudpathlib Changelog
 
+## UNRELEASED
+
+- Fixed mypy 2.x type errors in `Client` and `CloudPath` that caused CI lint failures (Issue [#563](https://github.com/drivendataorg/cloudpathlib/issues/563), PR [#566](https://github.com/drivendataorg/cloudpathlib/pull/566))
+
 ## v0.24.0 (2026-04-29)
 - Added support for S3 Multi-Region Access Point (MRAP) URLs in `S3Path` (Issue [#556](https://github.com/drivendataorg/cloudpathlib/issues/556), PR [#557](https://github.com/drivendataorg/cloudpathlib/pull/557))
 - Added support for Pydantic serialization (Issue [#537](https://github.com/drivendataorg/cloudpathlib/issues/537), PR [#538](https://github.com/drivendataorg/cloudpathlib/pull/538))

--- a/cloudpathlib/client.py
+++ b/cloudpathlib/client.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import shutil
 from tempfile import TemporaryDirectory
-from typing import Generic, Callable, Iterable, Optional, Tuple, TypeVar, Union
+from typing import ClassVar, Generic, Callable, Iterable, Optional, Tuple, TypeVar, Union
 
 from .cloudpath import CloudImplementation, CloudPath, implementation_registry
 from .enums import FileCacheMode
@@ -27,7 +27,7 @@ def register_client_class(key: str) -> Callable:
 
 class Client(abc.ABC, Generic[BoundedCloudPath]):
     _cloud_meta: CloudImplementation
-    _default_client = None
+    _default_client: ClassVar[Optional["Client[BoundedCloudPath]"]] = None
 
     def __init__(
         self,
@@ -95,7 +95,7 @@ class Client(abc.ABC, Generic[BoundedCloudPath]):
                 self._local_cache_dir.rmdir()
 
     @classmethod
-    def get_default_client(cls) -> "Client":
+    def get_default_client(cls) -> "Client[BoundedCloudPath]":
         """Get the default client, which the one that is used when instantiating a cloud path
         instance for this cloud without a client specified.
         """

--- a/cloudpathlib/cloudpath.py
+++ b/cloudpathlib/cloudpath.py
@@ -907,8 +907,10 @@ class CloudPath(metaclass=CloudPathMeta):
             sequence_class = (
                 type(path_version) if not isinstance(path_version, _PathParents) else tuple
             )
-            return sequence_class(  # type: ignore
-                self._new_cloudpath(_resolve(p)) for p in path_version if _resolve(p) != p.root
+            return sequence_class(  # type: ignore[call-arg]
+                self._new_cloudpath(_resolve(p))
+                for p in path_version
+                if isinstance(p, PurePosixPath) and _resolve(p) != p.root
             )
 
         # when pathlib returns something else, we probably just want that thing


### PR DESCRIPTION
Latest mypy 2.x reports type errors that cause `make lint` to fail when dev dependencies are upgraded. This PR adds a `ClassVar` annotation for `Client._default_client` and narrows the return type of `get_default_client()` so lazy initialization type-checks correctly. In `CloudPath._dispatch_to_path`, path parent sequences now filter with `isinstance(p, PurePosixPath)` before calling `_resolve`. Linting passes locally with black, flake8, and mypy.

Closes #563 
