### PR TITLE
Add local pre-signed URL placeholders

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- Added placeholder pre-signed URLs for local cloud path implementations to support testing code that generates signed URLs (Issue [#525](https://github.com/drivendataorg/cloudpathlib/issues/525)).
 - Fixed mypy 2.x type errors in `Client` and `CloudPath` that caused CI lint failures (Issue [#563](https://github.com/drivendataorg/cloudpathlib/issues/563), PR [#566](https://github.com/drivendataorg/cloudpathlib/pull/566))
 - Changed `S3Client._get_metadata` to read object metadata with `HeadObject` instead of `GetObject`, so `stat`, `etag`, and `size` no longer open the object body. Also fixes a `KeyError` on `ContentLength` against S3-compatible gateways that drop `Content-Length` from `GetObject` responses. (Issue [#564](https://github.com/drivendataorg/cloudpathlib/issues/564), PR [#565](https://github.com/drivendataorg/cloudpathlib/pull/565))
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Added placeholder pre-signed URLs for local cloud path implementations to support testing code that generates signed URLs (Issue [#525](https://github.com/drivendataorg/cloudpathlib/issues/525)).
+- Added placeholder pre-signed URLs for local cloud path implementations to support testing code that generates signed URLs (Issue [#525](https://github.com/drivendataorg/cloudpathlib/issues/525), PR [#568](https://github.com/drivendataorg/cloudpathlib/pull/568)).
 - Fixed mypy 2.x type errors in `Client` and `CloudPath` that caused CI lint failures (Issue [#563](https://github.com/drivendataorg/cloudpathlib/issues/563), PR [#566](https://github.com/drivendataorg/cloudpathlib/pull/566))
 - Changed `S3Client._get_metadata` to read object metadata with `HeadObject` instead of `GetObject`, so `stat`, `etag`, and `size` no longer open the object body. Also fixes a `KeyError` on `ContentLength` against S3-compatible gateways that drop `Content-Length` from `GetObject` responses. (Issue [#564](https://github.com/drivendataorg/cloudpathlib/issues/564), PR [#565](https://github.com/drivendataorg/cloudpathlib/pull/565))
 

--- a/cloudpathlib/local/localclient.py
+++ b/cloudpathlib/local/localclient.py
@@ -8,6 +8,7 @@ import sys
 from tempfile import TemporaryDirectory
 from time import sleep
 from typing import Callable, ClassVar, Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import urlencode
 
 from ..client import Client
 from ..enums import FileCacheMode
@@ -207,7 +208,13 @@ class LocalClient(Client):
     def _generate_presigned_url(
         self, cloud_path: "LocalPath", expire_seconds: int = 60 * 60
     ) -> str:
-        raise NotImplementedError("Cannot generate a presigned URL for a local path.")
+        query = urlencode(
+            {
+                "cloudpathlib-local": "true",
+                "expires": expire_seconds,
+            }
+        )
+        return f"{cloud_path.as_uri()}?{query}"
 
 
 _temp_dirs_to_clean: List[TemporaryDirectory] = []

--- a/docs/docs/script/testing_mocked_cloudpathlib.py
+++ b/docs/docs/script/testing_mocked_cloudpathlib.py
@@ -8,7 +8,9 @@
 # ## cloudpathlib.local module
 # 
 # In the `cloudpathlib.local` module, we provide "Local" classes that use the local filesystem in place of cloud storage. These classes are drop-in replacements for the normal cloud path classes, with the intent that you can use them as mock or monkeypatch substitutes in your tests. 
-# 
+#
+# Local paths return placeholder URLs from `as_url(presign=True)` so code that generates pre-signed URLs can be tested. These URLs are not signed and cannot be used to access files.
+#
 # We also provide `CloudImplementation` objects which can be used to replace a registered implementation in the `cloudpathlib.implementation_registry` dictionary. Replacing the registered implementation will make `CloudPath`'s automatic dispatching use the replacement. 
 # 
 # See the examples below for how to use these replacements in your tests.
@@ -79,4 +81,3 @@ get_ipython().run_cell_magic('run_pytest[clean]', '', '\nfrom cloudpathlib impor
 # Finally, the `reset_default_storage_dir` class method will clean up the current local storage temporary directory and set up a new one. We recommend you do this in the teardown of the test fixture. 
 
 get_ipython().run_cell_magic('run_pytest[clean]', '', '\nimport pytest\n\nfrom cloudpathlib import CloudPath, implementation_registry\nfrom cloudpathlib.local import LocalS3Client, LocalS3Path, local_s3_implementation\n\n\n@pytest.fixture\ndef cloud_asset_file(monkeypatch):\n    """Fixture that patches CloudPath dispatch and also sets up test assets in LocalS3Client\'s\n    local storage directory."""\n\n    monkeypatch.setitem(implementation_registry, "s3", local_s3_implementation)\n\n    # Option 1: Use LocalS3Path to set up test assets directly\n    local_cloud_path = LocalS3Path("s3://cloudpathlib-test-bucket/altostratus.txt")\n    local_cloud_path.write_text("altostratus")\n    \n    # Option 2: Use the pathlib.Path object that points to the local storage directory\n    local_pathlib_path: Path = (\n        LocalS3Client.get_default_storage_dir() / "cloudpathlib-test-bucket" / "nimbostratus.txt"\n    )\n    local_pathlib_path.parent.mkdir(exist_ok=True, parents=True)\n    local_pathlib_path.write_text("nimbostratus")\n\n    yield\n\n    LocalS3Client.reset_default_storage_dir()  # clean up temp directory and replace with new one\n\n\ndef test_with_assets(cloud_asset_file):\n    """Testing that a patched CloudPath finds the test asset created in the fixture."""\n\n    cloud_path_1 = CloudPath("s3://cloudpathlib-test-bucket/altostratus.txt")\n    assert isinstance(cloud_path_1, LocalS3Path)\n    assert cloud_path_1.exists()\n    assert cloud_path_1.read_text() == "altostratus"\n    \n    cloud_path_2 = CloudPath("s3://cloudpathlib-test-bucket/nimbostratus.txt")\n    assert isinstance(cloud_path_2, LocalS3Path)\n    assert cloud_path_2.exists()\n    assert cloud_path_2.read_text() == "nimbostratus"\n')
-

--- a/docs/docs/testing_mocked_cloudpathlib.ipynb
+++ b/docs/docs/testing_mocked_cloudpathlib.ipynb
@@ -22,6 +22,8 @@
     "\n",
     "In the `cloudpathlib.local` module, we provide \"Local\" classes that use the local filesystem in place of cloud storage. These classes are drop-in replacements for the normal cloud path classes, with the intent that you can use them as mock or monkeypatch substitutes in your tests. \n",
     "\n",
+    "Local paths return placeholder URLs from `as_url(presign=True)` so code that generates pre-signed URLs can be tested. These URLs are not signed and cannot be used to access files.\n",
+    "\n",
     "We also provide `CloudImplementation` objects which can be used to replace a registered implementation in the `cloudpathlib.implementation_registry` dictionary. Replacing the registered implementation will make `CloudPath`'s automatic dispatching use the replacement. \n",
     "\n",
     "See the examples below for how to use these replacements in your tests.\n",

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,6 +1,7 @@
 import pytest
 
 from inspect import signature
+from urllib.parse import parse_qs, urlparse
 
 from cloudpathlib import AzureBlobClient, AzureBlobPath, GSClient, GSPath, S3Client, S3Path
 from cloudpathlib.local import (
@@ -120,6 +121,26 @@ def test_reset_default_storage_dir_with_default_client():
     LocalS3Client.reset_default_storage_dir()
     s3p2 = LocalS3Path("s3://drive/file.txt")
     assert not s3p2.exists()
+
+
+@pytest.mark.parametrize("client_class", [LocalAzureBlobClient, LocalGSClient, LocalS3Client])
+def test_presigned_url_placeholder(client_class, monkeypatch):
+    if client_class is LocalAzureBlobClient:
+        monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+    cloud_prefix = client_class._cloud_meta.path_class.cloud_prefix
+    path = client_class().CloudPath(f"{cloud_prefix}drive/file.txt")
+    expire_seconds = 300
+
+    url = urlparse(path.as_url(presign=True, expire_seconds=expire_seconds))
+
+    assert url.scheme == cloud_prefix.removesuffix("://")
+    assert url.netloc == "drive"
+    assert url.path == "/file.txt"
+    assert parse_qs(url.query) == {
+        "cloudpathlib-local": ["true"],
+        "expires": [str(expire_seconds)],
+    }
 
 
 @pytest.mark.parametrize("client_class", [LocalAzureBlobClient, LocalGSClient, LocalS3Client])


### PR DESCRIPTION
## Summary

- return a clearly marked placeholder URL when local cloud paths are presigned
- preserve the requested expiry in the placeholder query parameters
- cover Azure, Google Cloud Storage, and S3 local implementations
- document that local placeholder URLs cannot access files

Closes #525

## Testing

- `make lint`
- `.venv/bin/python -m pytest -q`
- 1019 passed, 5 skipped

## Contributor checklist

- [x] I have read and understood `CONTRIBUTING.md`
- [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary
- [x] Confirmed PR is based on the latest `master`
- [x] Confirmed failure before change and success after change
- [x] Any generic new functionality is replicated across cloud providers if necessary
- [ ] Tested manually against live server backend for at least one provider
- [x] Added tests for the new functionality
- [x] Linting passes locally
- [x] Tests pass locally
- [x] Updated `HISTORY.md` with the issue and PR addressed
