### PR TITLE
Delegate AWS endpoint environment handling

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- Delegated `AWS_ENDPOINT_URL` handling to boto3 now that the AWS SDK supports endpoint environment variables directly (Issue [#194](https://github.com/drivendataorg/cloudpathlib/issues/194)).
 - Fixed mypy 2.x type errors in `Client` and `CloudPath` that caused CI lint failures (Issue [#563](https://github.com/drivendataorg/cloudpathlib/issues/563), PR [#566](https://github.com/drivendataorg/cloudpathlib/pull/566))
 - Changed `S3Client._get_metadata` to read object metadata with `HeadObject` instead of `GetObject`, so `stat`, `etag`, and `size` no longer open the object body. Also fixes a `KeyError` on `ContentLength` against S3-compatible gateways that drop `Content-Length` from `GetObject` responses. (Issue [#564](https://github.com/drivendataorg/cloudpathlib/issues/564), PR [#565](https://github.com/drivendataorg/cloudpathlib/pull/565))
 

--- a/cloudpathlib/s3/s3client.py
+++ b/cloudpathlib/s3/s3client.py
@@ -79,7 +79,6 @@ class S3Client(Client):
                 args that are supported look at the upload and download lists in the
                 [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer).
         """
-        endpoint_url = endpoint_url or os.getenv("AWS_ENDPOINT_URL")
         if boto3_session is not None:
             self.sess = boto3_session
         else:

--- a/tests/test_s3_specific.py
+++ b/tests/test_s3_specific.py
@@ -254,12 +254,10 @@ def test_extra_args_via_requester_pays(s3_rig, tmp_path):
 
 
 def test_aws_endpoint_url_env(monkeypatch):
-    """Allows setting endpoint_url from env variable
-    until upstream boto3 PR is merged.
-    https://github.com/boto/boto3/pull/2746
-    """
+    """Delegates AWS_ENDPOINT_URL handling to boto3."""
     s3_url = "https://s3.amazonaws.com"
     localstack_url = "http://localhost:4566"
+    explicit_url = "http://localhost:9000"
 
     s3_client = S3Client()
     assert s3_client.client.meta.endpoint_url == s3_url
@@ -267,6 +265,9 @@ def test_aws_endpoint_url_env(monkeypatch):
     monkeypatch.setenv("AWS_ENDPOINT_URL", localstack_url)
     s3_client_custom_endpoint = S3Client()
     assert s3_client_custom_endpoint.client.meta.endpoint_url == localstack_url
+
+    s3_client_explicit_endpoint = S3Client(endpoint_url=explicit_url)
+    assert s3_client_explicit_endpoint.client.meta.endpoint_url == explicit_url
 
 
 def test_as_url_local(monkeypatch):


### PR DESCRIPTION
## Summary

- remove cloudpathlib's custom `AWS_ENDPOINT_URL` lookup
- delegate endpoint environment variable handling to boto3/botocore
- verify an explicit `endpoint_url` still takes precedence

Closes #194

## Testing

- `make lint`
- `.venv/bin/python -m pytest -q`
- 1016 passed, 5 skipped

## Contributor checklist

- [x] I have read and understood `CONTRIBUTING.md`
- [x] Confirmed an issue exists for the PR, and the text `Closes #issue` appears in the PR summary
- [x] Confirmed PR is based on the latest `master`
- [x] Confirmed failure before change and success after change
- [x] Any generic new functionality is replicated across cloud providers if necessary
- [ ] Tested manually against live server backend for at least one provider
- [x] Added tests for the updated behavior
- [x] Linting passes locally
- [x] Tests pass locally
- [x] Updated `HISTORY.md` with the issue addressed
