### PR TITLE
Pin pytest<9.1 to fix CI failure

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ pandas
 pillow
 psutil
 pydantic
-pytest
+pytest<9.1
 pytest-cases>=3.9.1
 pytest-cov
 pytest-duration-insights


### PR DESCRIPTION
pytest 9.1.0 was released on 2026-06-13 and changed the internal `IdMaker` API in a way that breaks `pytest-cases`, which only officially supports pytest 6, 7, and 8 (through its latest release 3.10.1). This pins `pytest<9.1` so CI resolves to pytest 9.0.3, which is compatible with `pytest-cases`.

Closes #570
