### PR TITLE
Add local presigned URL implementation for local clients

### DIFF
--- a/cloudpathlib/local/localclient.py
+++ b/cloudpathlib/local/localclient.py
@@ -8,6 +8,7 @@ import sys
 from tempfile import TemporaryDirectory
 from time import sleep
 from typing import Callable, ClassVar, Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from ..client import Client
 from ..enums import FileCacheMode
@@ -207,7 +208,12 @@ class LocalClient(Client):
     def _generate_presigned_url(
         self, cloud_path: "LocalPath", expire_seconds: int = 60 * 60
     ) -> str:
-        raise NotImplementedError("Cannot generate a presigned URL for a local path.")
+        public_url = self._get_public_url(cloud_path)
+        parts = urlsplit(public_url)
+        query = dict(parse_qsl(parts.query, keep_blank_values=True))
+        query["expires"] = str(expire_seconds)
+        query["signature"] = "local"
+        return urlunsplit(parts._replace(query=urlencode(query)))
 
 
 _temp_dirs_to_clean: List[TemporaryDirectory] = []

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,6 +1,7 @@
 import pytest
 
 from inspect import signature
+from urllib.parse import parse_qs, urlsplit
 
 from cloudpathlib import AzureBlobClient, AzureBlobPath, GSClient, GSPath, S3Client, S3Path
 from cloudpathlib.local import (
@@ -133,3 +134,22 @@ def test_glob_matches(client_class, monkeypatch):
 
     # match CloudPath, which returns empty; not glob module, which raises
     assert list(p.glob("*")) == []
+
+
+@pytest.mark.parametrize("client_class", [LocalAzureBlobClient, LocalGSClient, LocalS3Client])
+def test_as_url_presign(client_class, monkeypatch):
+    if client_class is LocalAzureBlobClient:
+        monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+    cloud_prefix = client_class._cloud_meta.path_class.cloud_prefix
+    p = client_class().CloudPath(f"{cloud_prefix}drive/file.txt")
+    p.write_text("hello")
+
+    expire_seconds = 123
+    presigned_url = p.as_url(presign=True, expire_seconds=expire_seconds)
+    parts = urlsplit(presigned_url)
+    query_params = parse_qs(parts.query)
+
+    assert parts.path.endswith("file.txt")
+    assert query_params["expires"] == [str(expire_seconds)]
+    assert query_params["signature"] == ["local"]


### PR DESCRIPTION
## Why
Using `cloudpathlib.local` as a drop-in test substitute currently fails when code calls `as_url(presign=True)`, because local clients raise `NotImplementedError`. This breaks the documented local-testing workflow for code paths that generate presigned URLs.

## What changed
`LocalClient._generate_presigned_url` now returns a deterministic local URL instead of raising. It reuses the local public URL and appends stable query parameters:
- `expires=<expire_seconds>`
- `signature=local`

This keeps behavior simple and predictable for tests while preserving the existing `expire_seconds` interface.

## Tests
Added `test_as_url_presign` in `tests/test_local.py` to verify presigned URL generation for:
- `LocalAzureBlobClient`
- `LocalGSClient`
- `LocalS3Client`

The test checks that the file path is preserved and expected query parameters are present.

Closes #525 